### PR TITLE
Remove $slider_stretch default

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -432,10 +432,6 @@ function vantage_render_slider(){
 				$slider = $page_slider;
 			}
 			$slider_stretch = get_post_meta($page_id, 'vantage_metaslider_slider_stretch', true);
-			if( $slider_stretch === '' ) {
-				// We'll default to whatever the home page slider stretch setting is
-				$slider_stretch = siteorigin_setting('home_slider_stretch');
-			}
 		}
 	}
 


### PR DESCRIPTION
[Slack Reference](https://siteorigin.slack.com/archives/themes/p1478591775000265)

With $slider_stretch being set to the default when vantage_metaslider_slider_stretch is empty (which is the case when not enabled), it's impossible to have a regular non-stretched page if the homepage is stretched.