### PR TITLE
filter hentry from post_class() to resolve core issue

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -464,6 +464,15 @@ function vantage_post_class_filter($classes){
 		$classes[] = 'post-with-thumbnail';
 		$classes[] = 'post-with-thumbnail-' . siteorigin_setting( 'blog_featured_image_type' );
 	}
+	
+	// Resolves structured data issue in core. See https://core.trac.wordpress.org/ticket/28482
+	if( is_page() ){
+		$class_key = array_search( 'hentry', $classes );
+
+		if( $class_key !== false) {
+			unset( $classes[ $class_key ] );
+		}
+	}
 
 	$classes = array_unique($classes);
 	return $classes;

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -163,23 +163,3 @@ function vantage_excerpt_length( $length ) {
 }
 endif;
 add_filter( 'excerpt_length', 'vantage_excerpt_length', 10 );
-
-if ( ! function_exists( 'vantage_hentry_filter' ) ) :
-/**
- * Resolves structured data issue in core. See https://core.trac.wordpress.org/ticket/28482
- */
-function vantage_hentry_filter( $classes ) {
-	global $post;
-
-	if( $post->post_type == 'page' ){
-		foreach( $classes as $class_key => $class ){
-			if( $class == 'hentry' ){
-				unset( $classes[ $class_key ] );
-			}
-		}
-	}
-
-	return $classes;
-}
-endif;
-add_filter( 'post_class', 'so_hentry_filter' );

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -163,3 +163,23 @@ function vantage_excerpt_length( $length ) {
 }
 endif;
 add_filter( 'excerpt_length', 'vantage_excerpt_length', 10 );
+
+if ( ! function_exists( 'vantage_hentry_filter' ) ) :
+/**
+ * Resolves structured data issue in core. See https://core.trac.wordpress.org/ticket/28482
+ */
+function vantage_hentry_filter( $classes ) {
+	global $post;
+
+	if( $post->post_type == 'page' ){
+		foreach( $classes as $class_key => $class ){
+			if( $class == 'hentry' ){
+				unset( $classes[ $class_key ] );
+			}
+		}
+	}
+
+	return $classes;
+}
+endif;
+add_filter( 'post_class', 'so_hentry_filter' );


### PR DESCRIPTION
Resolves structured data issue in core. See https://core.trac.wordpress.org/ticket/28482

To summarize, hentry shouldn't be present on pages as it will never have the data it'ss required to have. This core issue won't be resolved due to backwards compatibility concerns.

Related to #204.