### PR TITLE
iOS Safari: resolve color issue for phone numbers

### DIFF
--- a/style.less
+++ b/style.less
@@ -2032,3 +2032,9 @@ body.layout-full{
 @import "less/icons";
 @import "less/jwplayer";
 @import "less/accessibility";
+
+/* Prevent iOS Safari from overriding the colors for phone numbers */
+a[href^="tel"]{
+    color:inherit;
+    text-decoration:none;
+}


### PR DESCRIPTION
Prevent iOS Safari from overriding the colors for phone numbers while still retaining the auto link functionality. A meta tag wouldn't allow this.

https://developer.apple.com/library/content/featuredarticles/iPhoneURLScheme_Reference/PhoneLinks/PhoneLinks.html