### PR TITLE
Add wide-grey support for PB 2.5

### DIFF
--- a/less/widgets.less
+++ b/less/widgets.less
@@ -747,13 +747,15 @@
 	}
 }
 
-.panel-row-style-wide-grey {
+.panel-row-style-wide-grey,
+.wide-grey.panel-row-style {
 	background: #f6f6f6;
 	border-top: 1px solid #dddddd;
 	border-bottom: 1px solid #dddddd;
 }
 
 .layout-full .panel-row-style.panel-row-style-wide-grey,
+.layout-full ..wide-grey.panel-row-style,
 .layout-full .panel-row-style.panel-row-style-full-width,
 .layout-full.panels-style-force-full .panel-row-style{
 	margin: 0 -1000px;
@@ -764,7 +766,7 @@
 	.panel-row-style{
 		padding: 25px 35px;
 
-		&.panel-row-style-wide-grey {
+		&.panel-row-style-wide-grey, .wide-grey.panel-row-style {
 			margin: 0 -20px;
 		}
 	}
@@ -776,7 +778,7 @@
 			margin: 0 -35px;
 			padding: 25px 35px;
 
-			&.panel-row-style-wide-grey {
+			&.panel-row-style-wide-grey, .wide-grey.panel-row-style {
 				margin: 0 -20px;
 			}
 		}

--- a/style.css
+++ b/style.css
@@ -3087,12 +3087,14 @@ body.layout-full {
 .panel-row-style .panel-row-style {
   margin: 0;
 }
-.panel-row-style-wide-grey {
+.panel-row-style-wide-grey,
+.wide-grey.panel-row-style {
   background: #f6f6f6;
   border-top: 1px solid #dddddd;
   border-bottom: 1px solid #dddddd;
 }
 .layout-full .panel-row-style.panel-row-style-wide-grey,
+.layout-full .wide-grey.panel-row-style,
 .layout-full .panel-row-style.panel-row-style-full-width,
 .layout-full.panels-style-force-full .panel-row-style {
   margin: 0 -1000px;
@@ -3101,7 +3103,8 @@ body.layout-full {
 .layout-boxed .panel-row-style {
   padding: 25px 35px;
 }
-.layout-boxed .panel-row-style.panel-row-style-wide-grey {
+.layout-boxed .panel-row-style.panel-row-style-wide-grey,
+.layout-boxed .wide-grey.panel-row-style {
   margin: 0 -20px;
 }
 @media (max-width: 680px) {
@@ -3109,7 +3112,8 @@ body.layout-full {
     margin: 0 -35px;
     padding: 25px 35px;
   }
-  body.responsive.layout-boxed .panel-row-style.panel-row-style-wide-grey {
+  body.responsive.layout-boxed .panel-row-style.panel-row-style-wide-grey,
+  body.responsive.layout-boxed .wide-grey.panel-row-style {
     margin: 0 -20px;
   }
 }


### PR DESCRIPTION
Currently, the default layout won't look 100% as intended due to SiteOrigin Page Builder 2.5 row class changes. This PR fixes this and maintains compatibility with older versions of PB.