### PR TITLE
Change .assistive-text element to span rather than h1

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -31,7 +31,7 @@
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through ?>
 		<nav role="navigation" id="comment-nav-above" class="site-navigation comment-navigation">
-			<h1 class="assistive-text"><?php _e( 'Comment navigation', 'vantage' ); ?></h1>
+			<span class="assistive-text"><?php _e( 'Comment navigation', 'vantage' ); ?></span>
 			<div class="nav-previous"><?php previous_comments_link( __( '&larr; Older Comments', 'vantage' ) ); ?></div>
 			<div class="nav-next"><?php next_comments_link( __( 'Newer Comments &rarr;', 'vantage' ) ); ?></div>
 		</nav><!-- #comment-nav-before .site-navigation .comment-navigation -->
@@ -43,7 +43,7 @@
 
 		<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : // are there comments to navigate through ?>
 		<nav role="navigation" id="comment-nav-below" class="site-navigation comment-navigation">
-			<h1 class="assistive-text"><?php _e( 'Comment navigation', 'vantage' ); ?></h1>
+			<span class="assistive-text"><?php _e( 'Comment navigation', 'vantage' ); ?></span>
 			<div class="nav-previous"><?php previous_comments_link( __( '&larr; Older Comments', 'vantage' ) ); ?></div>
 			<div class="nav-next"><?php next_comments_link( __( 'Newer Comments &rarr;', 'vantage' ) ); ?></div>
 		</nav><!-- #comment-nav-below .site-navigation .comment-navigation -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -82,7 +82,7 @@ function vantage_content_nav( $nav_id ) {
 
 	?>
 	<nav role="navigation" id="<?php echo esc_attr( $nav_id ); ?>" class="<?php echo $nav_class; ?>">
-		<h1 class="assistive-text"><?php _e( 'Post navigation', 'vantage' ); ?></h1>
+		<span class="assistive-text"><?php _e( 'Post navigation', 'vantage' ); ?></span>
 
 	<?php if ( is_single() ) : // navigation links for single posts ?>
 


### PR DESCRIPTION
There's little reason to have the elements that .assistive-text is attached to is to be h1 so this PR will change it to a span.