### PR TITLE
Page Navigation Wrap: Allow for text to wrap on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1831,6 +1831,7 @@ article.page.post-with-thumbnail-icon .entry-main {
     width: 100%;
     margin-bottom: 20px;
     text-align: center;
+    white-space: normal;
   }
 }
 /* =Comments

--- a/style.less
+++ b/style.less
@@ -1662,6 +1662,7 @@ article.page{
 				width: 100%;
 				margin-bottom: 20px;
 				text-align: center;
+				white-space: normal;
 			}
 		}
 	}


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/post-navigation-buttons-get-cut-off-on-mobile/)

This PR will allow for the page navigation to wrap on mobile devices. This helps prevent the navigation from getting cut off when the post names are slightly larger.

![](https://i.imgur.com/Q2hglcj.png)

(image sourced from the above linked thread)