### PR TITLE
Loops: Fix slider alignment

### DIFF
--- a/less/loops.less
+++ b/less/loops.less
@@ -239,13 +239,19 @@
 	}
 }
 
-.widget_siteorigin-panels-postloop h1.entry-title {
-	margin-top: 0;
-	margin-bottom: 0;
-}
+.widget_siteorigin-panels-postloop {
+	h1.entry-title {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
 
-.widget_siteorigin-panels-postloop .pagination {
-	margin-top: 20px;
+	.pagination {
+		margin-top: 20px;
+	}
+
+	.flexslider .slides .slide {
+		margin-left: 0;
+	}
 }
 
 @media (max-width:640px) {

--- a/style.css
+++ b/style.css
@@ -3366,6 +3366,9 @@ html[xmlns] .slides {
 .widget_siteorigin-panels-postloop .pagination {
   margin-top: 20px;
 }
+.widget_siteorigin-panels-postloop .flexslider .slides .slide {
+  margin-left: 0;
+}
 @media (max-width: 640px) {
   body.responsive .vantage-grid-loop article,
   body.responsive .vantage-circleicon-loop .widget_circleicon-widget {


### PR DESCRIPTION
This PR will ensure no margin is applied to the slider loop list items. Currently,  the default list styling (which is applied to `.entry-content ul li`) is.

![](https://i.imgur.com/IdVPduO.png)