### PR TITLE
Loop carousel: Rename overlay to prevent conflicts

### DIFF
--- a/less/loops.less
+++ b/less/loops.less
@@ -78,11 +78,11 @@
 					background-size: 242px 162px;
 					background-position: center center;
 
-					&, span.overlay {
+					&, span.vantage-overlay {
 						.transition(0.35s);
 					}
 
-					span.overlay {
+					span.vantage-overlay {
 						display: block;
 						width: 100%;
 						height: 100%;

--- a/loops/loop-carousel.php
+++ b/loops/loop-carousel.php
@@ -14,10 +14,9 @@
 					<?php $img = wp_get_attachment_image_src(get_post_thumbnail_id(), 'vantage-carousel'); ?>
 					<?php if( $img[0] ) : ?>
 						<a href="<?php the_permalink() ?>" style="background-image: url(<?php echo $img[0] ?>)">
-							<span class="sow-overlay"></span>
 						</a>
 					<?php else : ?>
-						<a href="<?php the_permalink() ?>" class="default-thumbnail"><span class="overlay"></span></a>
+						<a href="<?php the_permalink() ?>" class="default-thumbnail"><span class="vantage-overlay"></span></a>
 					<?php endif; ?>
 				</div>
 				<?php


### PR DESCRIPTION
A user has reported issues due to `.overlay` being used. This PR will rename the overlay class to `.vantage-overlay`