### PR TITLE
Multilingual home page slider

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+== 1.7.9 - 27 July 2018 ==
+* Restored the vantage .pot file to it's correct location caused by build script issue.
+
 == 1.7.8 - 14 July 2018 ==
 * Allow for mobile menu fragment links with ID's defined.
 


### PR DESCRIPTION
Currently the multilingual homepage sliders are not supported but with a small modification, they can be.

Related topic on WordPress.org: https://wordpress.org/support/topic/multilingual-home-page-slider/#post-10551461

So basically, the functions.php should have this code inside the vantage_render_slider() function:
```
if(is_customize_preview()){
    $settings_slider = siteorigin_setting( 'home_slider' );
} else {
    $page_id = get_the_ID();
    $settings_slider = get_post_meta($page_id, 'vantage_metaslider_slider', true);
}
```