### PR TITLE
Multilingual home page slider support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -426,11 +426,11 @@ if ( ! function_exists( 'vantage_render_slider' ) ) :
  */
 function vantage_render_slider() {
 	if ( is_front_page() && ! in_array( siteorigin_setting( 'home_slider' ), array( '', 'none' ) ) ) {
-		if(is_customize_preview()){
+		if( is_customize_preview() ){
 		    $settings_slider = siteorigin_setting( 'home_slider' );
 		} else {
 		    $page_id = get_the_ID();
-		    $settings_slider = get_post_meta($page_id, 'vantage_metaslider_slider', true);
+		    $settings_slider = get_post_meta( $page_id, 'vantage_metaslider_slider', true );
 		}
 		$slider_stretch = siteorigin_setting( 'home_slider_stretch' );
 		$slider = false;

--- a/functions.php
+++ b/functions.php
@@ -426,7 +426,12 @@ if ( ! function_exists( 'vantage_render_slider' ) ) :
  */
 function vantage_render_slider() {
 	if ( is_front_page() && ! in_array( siteorigin_setting( 'home_slider' ), array( '', 'none' ) ) ) {
-		$settings_slider = siteorigin_setting( 'home_slider' );
+		if(is_customize_preview()){
+		    $settings_slider = siteorigin_setting( 'home_slider' );
+		} else {
+		    $page_id = get_the_ID();
+		    $settings_slider = get_post_meta($page_id, 'vantage_metaslider_slider', true);
+		}
 		$slider_stretch = siteorigin_setting( 'home_slider_stretch' );
 		$slider = false;
 		


### PR DESCRIPTION
Currently the multilingual homepage sliders are not supported but with a small modification, they can be.

Related topic on WordPress.org: https://wordpress.org/support/topic/multilingual-home-page-slider/#post-10551461

(Hopefully this will go through fine.)