### PR TITLE
Dequeue flexslider when metaslider loads it

### DIFF
--- a/inc/sliders.php
+++ b/inc/sliders.php
@@ -16,7 +16,7 @@ if ( class_exists( 'MetaSliderPlugin' ) ) :
 			// Attempt to unregister the script (works only in the footer)
 			wp_dequeue_script( 'jquery-flexslider' );
 
-			// Attempt to unload MetaSlider (too late to unload MetaSlider's version)
+			// Attempt to unload MetaSlider (too late to unload Vantage's version)
 			if ( in_array( 'jquery-flexslider', $wp_scripts->done ) ) {
 
 				// Not ideal, but this loads after the head ok to just print the styles anywhere

--- a/inc/sliders.php
+++ b/inc/sliders.php
@@ -1,6 +1,35 @@
 <?php
 
 if ( class_exists( 'MetaSliderPlugin' ) ) :
+
+	/**
+	 * Dequeue the FlexSlider script if MetaSlider is loading theirs since
+	 * they have a custom version better suited to their plugin.
+	 */
+	if ( ! function_exists( 'vantage_remove_flexslider_if_metaslider' ) ) :
+	function vantage_remove_flexslider_if_metaslider() {
+		global $wp_scripts;
+
+		// Check if the user has FlexSlider set
+		if ( wp_script_is( 'metaslider-flex-slider' ) ) {
+
+			// Attempt to unregister the script (works only in the footer)
+			wp_dequeue_script( 'jquery-flexslider' );
+
+			// Attempt to unload MetaSlider (too late to unload MetaSlider's version)
+			if ( in_array( 'jquery-flexslider', $wp_scripts->done ) ) {
+
+				// Not ideal, but this loads after the head ok to just print the styles anywhere
+				$wp_scripts->print_inline_script( 'metaslider-flex-slider', 'after');
+
+				// Dequeue MetaSlider
+				wp_dequeue_script( 'metaslider-flex-slider' );
+			}
+		}
+	}
+	endif;
+	add_action( 'metaslider_register_public_styles', 'vantage_remove_flexslider_if_metaslider', 99 );
+	
 	/**
 	 * Add in the Vantage (Flex) theme.
 	 *


### PR DESCRIPTION
Hi,

I work on MetaSlider and had some issues with loading both versions of FlexSlider. This PR forces a choice when the MetaSlider's version is in the queue. Better to prefer my version as it has a few extra PRs that FlexSlider hasn't merged in (yet).

On another note, if you have any future issues with MetaSlider please tag my username and I will address them personally. Or if you have any ideas for better integration, etc I'm happy to discuss it. 

By the way, we are releasing a theming system "soon-ish" so maybe we can add in some Vantage-specific themes to really make the slideshows fit perfectly for your users.