### PR TITLE
Customizer setting callbacks: Account for empty values by using default value

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -555,10 +555,13 @@ class SiteOrigin_Customizer_Helper {
 				}
 			}
 
-			if(isset($setting['callback'])) {
+			if ( isset( $setting['callback'] ) && isset( $setting['default'] ) ) {
 				$val = get_theme_mod($id);
-				if(isset( $setting['default'] ) && $val != $setting['default']) {
-					call_user_func( $setting['callback'], $builder, $val, array_merge( $setting, array('id' => $id) ) );
+				if ( $val != $setting['default'] ) {
+					if ( empty( $val ) ) {
+						$val = $setting['default'];
+					}
+					call_user_func( $setting['callback'], $builder, $val, array_merge( $setting, array( 'id' => $id ) ) );
 				}
 			}
 		}

--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -555,7 +555,8 @@ class SiteOrigin_Customizer_Helper {
 				}
 			}
 
-			if ( isset( $setting['callback'] ) && isset( $setting['default'] ) ) {
+			$val = get_theme_mod($id);
+			if ( isset( $setting['callback'] ) && isset( $setting['default'] ) && $val != $setting['default'] ) {
 				$val = get_theme_mod($id);
 				if ( $val != $setting['default'] ) {
 					if ( empty( $val ) ) {


### PR DESCRIPTION
Resolve #277.

This is happening due to how customizer setting callbacks work Basically, the callback doesn't use the default value until after saving and this is an issue as the callback multiplies the value which is why it results in 0.

https://github.com/siteorigin/vantage/blob/1.7.14/inc/customizer.php#L729

While this issue could be fixed in the callback itself, it's quite possible other settings are also affected by this sort of issue and this PR will prevent this sort of issue.