### PR TITLE
Customizer setting callbacks: Allow setting to be set to 0

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -559,7 +559,7 @@ class SiteOrigin_Customizer_Helper {
 			if ( isset( $setting['callback'] ) && isset( $setting['default'] ) && $val != $setting['default'] ) {
 				$val = get_theme_mod($id);
 				if ( $val != $setting['default'] ) {
-					if ( empty( $val ) ) {
+					if ( ! isset( $val ) ) {
 						$val = $setting['default'];
 					}
 					call_user_func( $setting['callback'], $builder, $val, array_merge( $setting, array( 'id' => $id ) ) );


### PR DESCRIPTION
This is a follow up to #278. This will allow users to set the `Site Title Font Size` to `0` for those who want the site title to be restored to how it was pre #278 . This isn't the ideal way to do this but certain people like how this looks and completely removing the output of the site title will change how this looks.