### PR TITLE
Customizer setting callbacks: Account for non-number values

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -559,7 +559,8 @@ class SiteOrigin_Customizer_Helper {
 			if ( isset( $setting['callback'] ) && isset( $setting['default'] ) && $val != $setting['default'] ) {
 				$val = get_theme_mod($id);
 				if ( $val != $setting['default'] ) {
-					if ( ! is_numeric( $val ) ) {
+					// Reset the value to the default if the setting is meant to be a number
+					if ( is_numeric( $setting['default'] ) && ! is_numeric( $val ) ) {
 						$val = $setting['default'];
 					}
 					call_user_func( $setting['callback'], $builder, $val, array_merge( $setting, array( 'id' => $id ) ) );


### PR DESCRIPTION
Fixes an issue which prevents the Button Background Color setting and any other setting which relies on callbacks from setting correctly. I tested pretty much every other setting I could find and couldn't find any other issues. 😞 