### PR TITLE
Use default value for Site Title Font Size customizer setting.

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -728,6 +728,7 @@ add_action('wp_head', 'vantage_customizer_style', 20);
  */
 function vantage_customizer_callback_site_title_size($builder, $val, $setting){
 	$mh_layout = siteorigin_setting( 'layout_masthead' );
+	$val = empty( $val ) ? $setting['default'] : $val;
 	if ( $mh_layout == 'logo-in-menu' ) {
 		$builder->add_css('#masthead .hgroup h1, #masthead.masthead-logo-in-menu .logo > h1', 'font-size', $val*0.6 . 'px');
 	} else {

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -728,7 +728,7 @@ add_action('wp_head', 'vantage_customizer_style', 20);
  */
 function vantage_customizer_callback_site_title_size($builder, $val, $setting){
 	$mh_layout = siteorigin_setting( 'layout_masthead' );
-	$val = empty( $val ) ? $setting['default'] : $val;
+	$val = $val === false ? $setting['default'] : $val;
 	if ( $mh_layout == 'logo-in-menu' ) {
 		$builder->add_css('#masthead .hgroup h1, #masthead.masthead-logo-in-menu .logo > h1', 'font-size', $val*0.6 . 'px');
 	} else {

--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -554,14 +554,10 @@ class SiteOrigin_Customizer_Helper {
 					}
 				}
 			}
-
-			$val = get_theme_mod($id);
-			if ( isset( $setting['callback'] ) && isset( $setting['default'] ) && $val != $setting['default'] ) {
-				$val = get_theme_mod($id);
-				if ( $val != $setting['default'] ) {
-					if ( ! is_numeric( $val ) ) {
-						$val = $setting['default'];
-					}
+			
+			if ( isset( $setting['callback'] ) ) {
+				$val = get_theme_mod( $id );
+				if ( isset( $setting['default'] ) && $val != $setting['default'] ) {
 					call_user_func( $setting['callback'], $builder, $val, array_merge( $setting, array( 'id' => $id ) ) );
 				}
 			}


### PR DESCRIPTION
Reverts changes made by #278 to fix #277. Use default value for site title if input value is empty.

An alternative, more general fix is to pass the default value to `get_theme_mod` [here](https://github.com/siteorigin/vantage/blob/4bffb2c88102ea445436ff9a4a9b07b57697d526/inc/customizer/customizer.php#L559) and then remove the condition below it so the callback is called. I didn't do this because it seems like the intention was for callbacks to handle empty values and apply defaults it desired.