### PR TITLE
Remove circle icon loop featured image if false

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -24,7 +24,7 @@ endif;
 add_filter( 'wp_page_menu_args', 'vantage_page_menu_args' );
 
 
-if ( !function_exists( 'vantage_body_classes' ) ) :
+if ( ! function_exists( 'vantage_body_classes' ) ) :
 /**
  * Adds custom classes to the array of body classes.
  *
@@ -36,16 +36,16 @@ function vantage_body_classes( $classes ) {
 		$classes[] = 'group-blog';
 	}
 
-	if( siteorigin_setting('layout_responsive') ) {
+	if( siteorigin_setting( 'layout_responsive' ) ) {
 		$classes[] = 'responsive';
 	}
-	$classes[] = 'layout-'.siteorigin_setting('layout_bound');
+	$classes[] = 'layout-'.siteorigin_setting( 'layout_bound' );
 	$classes[] = 'no-js';
 
 	$is_full_width_template = is_page_template( 'templates/template-full.php' ) || is_page_template( 'templates/template-full-notitle.php' );
-	if( !$is_full_width_template ) {
+	if ( ! $is_full_width_template ) {
 		$wc_shop_sidebar = vantage_is_woocommerce_active() && is_shop() && is_active_sidebar( 'shop' );
-		if( !is_active_sidebar('sidebar-1') && !$wc_shop_sidebar ) {
+		if ( ! is_active_sidebar('sidebar-1') && ! $wc_shop_sidebar ) {
 			$classes[] = 'no-sidebar';
 		}
 		else {
@@ -53,31 +53,31 @@ function vantage_body_classes( $classes ) {
 		}
 	}
 
-	if( is_customize_preview() ) {
+	if ( is_customize_preview() ) {
 		$classes[] = 'so-vantage-customizer-preview';
 	}
 
-	if( wp_is_mobile() ) {
+	if ( wp_is_mobile() ) {
 		$classes[] = 'so-vantage-mobile-device';
 	}
 	$mega_menu_active = function_exists( 'max_mega_menu_is_enabled' ) && max_mega_menu_is_enabled( 'primary' );
-	if(siteorigin_setting('navigation_menu_search') && !$mega_menu_active) {
+	if ( siteorigin_setting('navigation_menu_search') && ! $mega_menu_active ) {
 		$classes[] = 'has-menu-search';
 	}
 
-	if( siteorigin_setting('layout_force_panels_full') ) {
+	if ( siteorigin_setting('layout_force_panels_full') ) {
 		$classes[] = 'panels-style-force-full';
 	}
 
 	$page_settings = siteorigin_page_setting();
 
-	if( !empty( $page_settings ) ) {
-		if( !empty( $page_settings['layout'] ) ) $classes[] = 'page-layout-' . $page_settings['layout'];
+	if ( ! empty( $page_settings ) ) {
+		if ( ! empty( $page_settings['layout'] ) ) $classes[] = 'page-layout-' . $page_settings['layout'];
 
-		if( empty( $page_settings['masthead_margin'] ) ) $classes[] = 'page-layout-no-masthead-margin';
-		if( empty( $page_settings['footer_margin'] ) ) $classes[] = 'page-layout-no-footer-margin';
-		if( !empty( $page_settings['hide_masthead'] ) ) $classes[] = 'page-layout-hide-masthead';
-		if( !empty( $page_settings['hide_footer_widgets'] ) ) $classes[] = 'page-layout-hide-footer-widgets';
+		if ( empty( $page_settings['masthead_margin'] ) ) $classes[] = 'page-layout-no-masthead-margin';
+		if ( empty( $page_settings['footer_margin'] ) ) $classes[] = 'page-layout-no-footer-margin';
+		if ( ! empty( $page_settings['hide_masthead'] ) ) $classes[] = 'page-layout-hide-masthead';
+		if ( ! empty( $page_settings['hide_footer_widgets'] ) ) $classes[] = 'page-layout-hide-footer-widgets';
 	}
 
 	if ( is_page() && is_page_template() ) {

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -26,7 +26,7 @@ class Vantage_CircleIcon_Widget extends WP_Widget {
 			'title_color' => '',
 			'text' => '',
 			'text_color' => '',
-			'circle_icon' => true,
+			'in_post_loop' => true,
 			'icon' => '',
 			'icon_color' => '',
 			'image' => '',
@@ -64,7 +64,7 @@ class Vantage_CircleIcon_Widget extends WP_Widget {
 		$target = (!empty($instance['more_target']) ? 'target="_blank"' : '');
 		?>
 		<div class="circle-icon-box circle-icon-position-<?php echo esc_attr($instance['icon_position']) ?> <?php echo empty($instance['box']) ? 'circle-icon-hide-box' : 'circle-icon-show-box' ?> circle-icon-size-<?php echo $instance['icon_size'] ?> <?php if ( siteorigin_setting( 'blog_featured_image_type' ) == 'none' ) echo 'no-archive-featured-image' ?>">
-			<?php if ( ! empty( $instance['circle_icon'] ) ) : ?>
+			<?php if ( ! empty( $instance['in_post_loop'] ) ) : ?>
 				<div class="circle-icon-wrapper">
 					<?php if(!empty($instance['more_url']) && !empty($instance['all_linkable'])) : ?><a href="<?php echo esc_url($instance['more_url']) ?>" class="link-icon" <?php echo $target ?>><?php endif; ?>
 					<div class="circle-icon<?php if(!empty($icon_styles)) echo ' icon-style-set' ?>" <?php if(!empty($icon_styles)) echo 'style="'.implode(';', $icon_styles).'"' ?>>

--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -26,6 +26,7 @@ class Vantage_CircleIcon_Widget extends WP_Widget {
 			'title_color' => '',
 			'text' => '',
 			'text_color' => '',
+			'circle_icon' => true,
 			'icon' => '',
 			'icon_color' => '',
 			'image' => '',
@@ -62,14 +63,16 @@ class Vantage_CircleIcon_Widget extends WP_Widget {
 
 		$target = (!empty($instance['more_target']) ? 'target="_blank"' : '');
 		?>
-		<div class="circle-icon-box circle-icon-position-<?php echo esc_attr($instance['icon_position']) ?> <?php echo empty($instance['box']) ? 'circle-icon-hide-box' : 'circle-icon-show-box' ?> circle-icon-size-<?php echo $instance['icon_size'] ?>">
-			<div class="circle-icon-wrapper">
-				<?php if(!empty($instance['more_url']) && !empty($instance['all_linkable'])) : ?><a href="<?php echo esc_url($instance['more_url']) ?>" class="link-icon" <?php echo $target ?>><?php endif; ?>
-				<div class="circle-icon<?php if(!empty($icon_styles)) echo ' icon-style-set' ?>" <?php if(!empty($icon_styles)) echo 'style="'.implode(';', $icon_styles).'"' ?>>
-					<?php if(!empty($icon)) : ?><div class="<?php echo esc_attr($icon); if(!empty($icon_styles)) echo ' icon-color-set' ?>" <?php if(!empty($icon_color)) echo 'style="'.$icon_color.'"' ?>></div><?php endif; ?>
+		<div class="circle-icon-box circle-icon-position-<?php echo esc_attr($instance['icon_position']) ?> <?php echo empty($instance['box']) ? 'circle-icon-hide-box' : 'circle-icon-show-box' ?> circle-icon-size-<?php echo $instance['icon_size'] ?> <?php if ( siteorigin_setting( 'blog_featured_image_type' ) == 'none' ) echo 'no-archive-featured-image' ?>">
+			<?php if ( ! empty( $instance['circle_icon'] ) ) : ?>
+				<div class="circle-icon-wrapper">
+					<?php if(!empty($instance['more_url']) && !empty($instance['all_linkable'])) : ?><a href="<?php echo esc_url($instance['more_url']) ?>" class="link-icon" <?php echo $target ?>><?php endif; ?>
+					<div class="circle-icon<?php if(!empty($icon_styles)) echo ' icon-style-set' ?>" <?php if(!empty($icon_styles)) echo 'style="'.implode(';', $icon_styles).'"' ?>>
+						<?php if(!empty($icon)) : ?><div class="<?php echo esc_attr($icon); if(!empty($icon_styles)) echo ' icon-color-set' ?>" <?php if(!empty($icon_color)) echo 'style="'.$icon_color.'"' ?>></div><?php endif; ?>
+					</div>
+					<?php if(!empty($instance['more_url']) && !empty($instance['all_linkable'])) : ?></a><?php endif; ?>
 				</div>
-				<?php if(!empty($instance['more_url']) && !empty($instance['all_linkable'])) : ?></a><?php endif; ?>
-			</div>
+			<?php endif; ?>
 
 			<?php if(!empty($instance['more_url']) && !empty($instance['all_linkable'])) : ?><a href="<?php echo esc_url($instance['more_url']) ?>" class="link-title" <?php echo $target ?>><?php endif; ?>
 			<?php if(!empty($instance['title'])) : ?><h4 <?php if(!empty($title_color)) echo 'style="'.$title_color.'"' ?>><?php echo wp_kses_post( apply_filters('widget_title', $instance['title'] ) ) ?></h4><?php endif; ?>

--- a/less/widgets.less
+++ b/less/widgets.less
@@ -336,6 +336,10 @@
 	}
 }
 
+.vantage-circleicon-loop .widget_circleicon-widget .no-archive-featured-image.circle-icon-position-top {
+	padding-top: 0 !important;
+}
+
 .widget_circleicon-widget {
 
 	@icon_size: 65px;

--- a/less/widgets.less
+++ b/less/widgets.less
@@ -337,7 +337,7 @@
 }
 
 .vantage-circleicon-loop .widget_circleicon-widget .no-archive-featured-image.circle-icon-position-top {
-	padding-top: 0 !important;
+	padding-top: 0;
 }
 
 .widget_circleicon-widget {
@@ -678,7 +678,7 @@
 					top: 2.5em;
 					left: -10px;
 					background: white;
-			
+
 					li {
 						position: relative;
 						list-style: none;

--- a/loops/loop-circleicon.php
+++ b/loops/loop-circleicon.php
@@ -4,11 +4,11 @@
  */
 ?>
 
-<?php if( have_posts() ) : $i = 0; ?>
-	<div id="vantage-circleicon-loop" class="vantage-circleicon-loop circleicon-loop-columns-<?php echo siteorigin_setting('blog_circle_column_count') ?>">
+<?php if ( have_posts() ) : $i = 0; ?>
+	<div id="vantage-circleicon-loop" class="vantage-circleicon-loop circleicon-loop-columns-<?php echo siteorigin_setting( 'blog_circle_column_count' ) ?>">
 
 		<?php
-		while( have_posts() ){
+		while ( have_posts() ) {
 			the_post();
 			$i++;
 			$image = wp_get_attachment_image_src( get_post_thumbnail_id() );
@@ -16,7 +16,8 @@
 			the_widget(
 				'Vantage_CircleIcon_Widget',
 				array(
-					'image' => !empty($image[0]) ? $image[0] : false,
+					'circle_icon' => siteorigin_setting( 'blog_featured_image_type' ) == 'none' ? false : true,
+					'image' => ! empty( $image[0] ) ? $image[0] : false,
 					'title' => get_the_title(),
 					'text' => get_the_excerpt(),
 					'more' => siteorigin_setting( 'blog_read_more' ) ? esc_html( siteorigin_setting( 'blog_read_more' ) ) : __( 'Continue reading', 'vantage' ),
@@ -26,7 +27,7 @@
 				)
 			);
 
-			if($i % siteorigin_setting( 'blog_circle_column_count' ) == 0) : ?><div class="clear"></div><?php endif;
+			if ( $i % siteorigin_setting( 'blog_circle_column_count' ) == 0 ) : ?><div class="clear"></div><?php endif;
 
 		}
 		?>

--- a/loops/loop-circleicon.php
+++ b/loops/loop-circleicon.php
@@ -16,7 +16,7 @@
 			the_widget(
 				'Vantage_CircleIcon_Widget',
 				array(
-					'circle_icon' => siteorigin_setting( 'blog_featured_image_type' ) == 'none' ? false : true,
+					'in_post_loop' => siteorigin_setting( 'blog_featured_image_type' ) == 'none' ? false : true,
 					'image' => ! empty( $image[0] ) ? $image[0] : false,
 					'title' => get_the_title(),
 					'text' => get_the_excerpt(),

--- a/loops/loop-grid.php
+++ b/loops/loop-grid.php
@@ -3,17 +3,17 @@
  * Loop Name: Grid
  */
 ?>
-<?php if( have_posts() ) : $i = 0; ?>
+<?php if ( have_posts() ) : $i = 0; ?>
 
-	<div id="vantage-grid-loop" class="vantage-grid-loop grid-loop-columns-<?php echo siteorigin_setting('blog_grid_column_count') ?>">
-		<?php while( have_posts() ): the_post(); $i++; ?>
+	<div id="vantage-grid-loop" class="vantage-grid-loop grid-loop-columns-<?php echo siteorigin_setting( 'blog_grid_column_count' ) ?>">
+		<?php while ( have_posts() ) : the_post(); $i++; ?>
 			<article <?php post_class(array('grid-post')) ?>>
 
-				<?php if( has_post_thumbnail() ) : ?>
+				<?php if ( has_post_thumbnail() && siteorigin_setting( 'blog_featured_image_type' ) !== 'none' ) : ?>
 					<a class="grid-thumbnail" href="<?php the_permalink() ?>">
 						<?php the_post_thumbnail('vantage-grid-loop') ?>
 					</a>
-				<?php elseif( 'attachment' == get_post_type() && wp_get_attachment_image_src(get_post_thumbnail_id(), 'vantage-grid-loop') ) : ?>
+				<?php elseif ( 'attachment' == get_post_type() && wp_get_attachment_image_src( get_post_thumbnail_id(), 'vantage-grid-loop' ) ) : ?>
 					<a class="grid-thumbnail" href="<?php the_permalink() ?>">
 						<?php echo wp_get_attachment_image( get_the_ID(), 'vantage-grid-loop' ); ?>
 					</a>
@@ -24,7 +24,7 @@
 				<?php $read_more_text = siteorigin_setting( 'blog_read_more' ) ? esc_html( siteorigin_setting( 'blog_read_more' ) ) : __( 'Continue reading', 'vantage' ); ?>
 				<?php echo ( siteorigin_setting( 'blog_read_more_button' ) ? '<a class="more-button" href="' . get_permalink() . '">' . $read_more_text . ' <i></i></a>' : '' ); ?>
 			</article>
-			<?php if($i % siteorigin_setting( 'blog_grid_column_count' ) == 0) : ?><div class="clear"></div><?php endif; ?>
+			<?php if ( $i % siteorigin_setting( 'blog_grid_column_count' ) == 0 ) : ?><div class="clear"></div><?php endif; ?>
 		<?php endwhile; ?>
 	</div>
 

--- a/style.css
+++ b/style.css
@@ -2759,6 +2759,9 @@ html[xmlns] .slides {
 .widget_icon-text .widget-title {
   margin: 15px 0;
 }
+.vantage-circleicon-loop .widget_circleicon-widget .no-archive-featured-image.circle-icon-position-top {
+  padding-top: 0 !important;
+}
 .widget_circleicon-widget {
   clear: both;
   /* A medium sized icon */

--- a/style.css
+++ b/style.css
@@ -2760,7 +2760,7 @@ html[xmlns] .slides {
   margin: 15px 0;
 }
 .vantage-circleicon-loop .widget_circleicon-widget .no-archive-featured-image.circle-icon-position-top {
-  padding-top: 0 !important;
+  padding-top: 0;
 }
 .widget_circleicon-widget {
   clear: both;


### PR DESCRIPTION
@AlexGStapleton Please, take a look mate. The goal is to remove the featured image from the Circle Icon post loop when the Customizer setting is none (Customize > Theme Settings > Blog > Featured Image Type: None). There should be no impact if the Featured Image Type is set to Small or Large and there shouldn't be any impact to the regular usage of the Circle Icon widget not in a post loop. Please, note that you'll need to test:

Circle Icon as a widget.
Circle Icon as the selected post loop for the blog.
Circle Icon as the template chosen within a Post Loop widget.