### PR TITLE
Add filter to prevent import of Google Font

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -87,8 +87,7 @@ class SiteOrigin_Customizer_CSS_Builder {
 		// Start by importing Google web fonts
 		$return = '<style type="text/css" id="customizer-css">';
 
-		$import_font = apply_filters( 'vanage_import_google_fonts', true );
-		if ( $import_font ) {
+		if ( apply_filters( 'vanage_import_google_fonts', true ) ) {
 			$import = array();
 			foreach ( $this->google_fonts as $font ) {
 				$import[ ] = urlencode( $font[ 0 ] ) . ':' . $font[ 1 ];

--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -87,13 +87,16 @@ class SiteOrigin_Customizer_CSS_Builder {
 		// Start by importing Google web fonts
 		$return = '<style type="text/css" id="customizer-css">';
 
-		$import = array();
-		foreach ( $this->google_fonts as $font ) {
-			$import[ ] = urlencode( $font[ 0 ] ) . ':' . $font[ 1 ];
-		}
-		$import = array_unique( $import );
-		if ( !empty( $import ) ) {
-			$return .= '@import url(//fonts.googleapis.com/css?family=' . implode( '|', $import ) . '); ';
+		$import_font = apply_filters( 'vanage_import_google_fonts', true );
+		if ( $import_font ) {
+			$import = array();
+			foreach ( $this->google_fonts as $font ) {
+				$import[ ] = urlencode( $font[ 0 ] ) . ':' . $font[ 1 ];
+			}
+			$import = array_unique( $import );
+			if ( !empty( $import ) ) {
+				$return .= '@import url(//fonts.googleapis.com/css?family=' . implode( '|', $import ) . '); ';
+			}
 		}
 
 		foreach ( $this->css as $selector => $rules ) {


### PR DESCRIPTION
This PR introduces the `vanage_import_google_fonts` filter which will allow users to prevent the @import of Google Fonts while still having the font styling being added. This will allow users to manually add the font using an alternative method and prevent Vantage from also importing.