### PR TITLE
Removed WC cart and checkout specific layouts

### DIFF
--- a/css/woocommerce.css
+++ b/css/woocommerce.css
@@ -387,24 +387,6 @@
   padding-bottom: 7px;
 }
 /* Page Layouts */
-.woocommerce-page.woocommerce-cart #primary,
-.woocommerce-page.woocommerce-checkout #primary {
-  float: left;
-  width: 71.287%;
-}
-.woocommerce-page.woocommerce-cart.no-sidebar #primary,
-.woocommerce-page.woocommerce-checkout.no-sidebar #primary {
-  float: none;
-  width: auto;
-}
-.woocommerce-page.woocommerce-cart.sidebar-position-left #primary,
-.woocommerce-page.woocommerce-checkout.sidebar-position-left #primary {
-  float: right;
-}
-.woocommerce-page.woocommerce-cart.sidebar-position-none #primary,
-.woocommerce-page.woocommerce-checkout.sidebar-position-none #primary {
-  width: 100%;
-}
 .woocommerce-page.woocommerce-checkout #ship-to-different-address-checkbox {
   margin: 3px 10px 0 0 ;
   float: left;

--- a/less/css/woocommerce.less
+++ b/less/css/woocommerce.less
@@ -402,29 +402,6 @@
 
 /* Page Layouts */
 .woocommerce-page {
-	&.woocommerce-cart,
-	&.woocommerce-checkout {
-		#primary {
-			float: left;
-			width: 71.287%;
-		}
-
-		&.no-sidebar {
-			#primary {
-				float: none;
-				width: auto;
-			}
-		}
-
-		&.sidebar-position-left #primary {
-			float: right;
-		}
-
-		&.sidebar-position-none #primary {
-			width: 100%;
-		}
-	}
-
 	&.woocommerce-checkout {
 		#ship-to-different-address-checkbox {
 			margin: 3px 10px 0 0 ;


### PR DESCRIPTION
This PR resolves #300. Currently, the WooCommerce cart and checkout pages don't respect Page Settings. The cart and checkout pages should now respect both page templates and page settings (No Sidebar etc.). Please, also test to ensure that Theme Design > Sidebar is working correctly on these pages. I have and it looks good, Left, Right and None are all working.