### PR TITLE
Customizer: Add ability to set setting description

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -462,7 +462,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
-						'description' => $setting['description'],
+						'description' => esc_html( $setting['description'] ),
 					) ) );
 					break;
 
@@ -472,7 +472,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
-						'description' => $setting['description'],
+						'description' => esc_html( $setting['description'] ),
 					) ) );
 					if ( empty( $setting['no_live'] ) ) $wp_customize->get_setting( $id )->transport = 'postMessage';
 					break;
@@ -483,7 +483,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'type'    => 'text',
 						'priority' => $priority++,
-						'description' => $setting['description'],
+						'description' => esc_html( $setting['description'] ),
 					) );
 					if( empty( $setting['no_live'] ) ) $wp_customize->get_setting( $id )->transport = 'postMessage';
 					break;
@@ -494,7 +494,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
-						'description' => $setting['description'],
+						'description' => esc_html( $setting['description'] ),
 					) ) );
 					break;
 
@@ -504,7 +504,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
-						'description' => $setting['description'],
+						'description' => esc_html( $setting['description'] ),
 					) ) );
 					break;
 
@@ -515,7 +515,7 @@ class SiteOrigin_Customizer_Helper {
 						'type'    => $setting['type'],
 						'priority' => $priority++,
 						'choices' => isset($setting['choices']) ? $setting['choices'] : null,
-						'description' => $setting['description'],
+						'description' => esc_html( $setting['description'] ),
 					) );
 					break;
 			}

--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -449,6 +449,11 @@ class SiteOrigin_Customizer_Helper {
 			// Can't use live changes with a callback
 			if( !empty($setting['callback']) ) $setting['no_live'] = true;
 
+			// Set $setting['description' ] if this setting doesn't have a description
+			if ( ! isset( $setting['description' ] ) ) {
+				$setting['description'] = '';
+			}
+
 			// Now lets add a control for this setting
 			switch($setting['type']) {
 				case 'font' :
@@ -457,7 +462,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
-						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
+						'description' => $setting['description'],
 					) ) );
 					break;
 
@@ -467,7 +472,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
-						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
+						'description' => $setting['description'],
 					) ) );
 					if ( empty( $setting['no_live'] ) ) $wp_customize->get_setting( $id )->transport = 'postMessage';
 					break;
@@ -478,7 +483,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'type'    => 'text',
 						'priority' => $priority++,
-						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
+						'description' => $setting['description'],
 					) );
 					if( empty( $setting['no_live'] ) ) $wp_customize->get_setting( $id )->transport = 'postMessage';
 					break;
@@ -489,7 +494,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
-						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
+						'description' => $setting['description'],
 					) ) );
 					break;
 
@@ -499,7 +504,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
-						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
+						'description' => $setting['description'],
 					) ) );
 					break;
 
@@ -510,7 +515,7 @@ class SiteOrigin_Customizer_Helper {
 						'type'    => $setting['type'],
 						'priority' => $priority++,
 						'choices' => isset($setting['choices']) ? $setting['choices'] : null,
-						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
+						'description' => $setting['description'],
 					) );
 					break;
 			}

--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -457,6 +457,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
+						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
 					) ) );
 					break;
 
@@ -466,6 +467,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
+						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
 					) ) );
 					if ( empty( $setting['no_live'] ) ) $wp_customize->get_setting( $id )->transport = 'postMessage';
 					break;
@@ -476,6 +478,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'type'    => 'text',
 						'priority' => $priority++,
+						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
 					) );
 					if( empty( $setting['no_live'] ) ) $wp_customize->get_setting( $id )->transport = 'postMessage';
 					break;
@@ -486,6 +489,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
+						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
 					) ) );
 					break;
 
@@ -495,6 +499,7 @@ class SiteOrigin_Customizer_Helper {
 						'section' => $setting['section'],
 						'settings' => $id,
 						'priority' => $priority++,
+						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
 					) ) );
 					break;
 
@@ -505,6 +510,7 @@ class SiteOrigin_Customizer_Helper {
 						'type'    => $setting['type'],
 						'priority' => $priority++,
 						'choices' => isset($setting['choices']) ? $setting['choices'] : null,
+						'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',
 					) );
 					break;
 			}


### PR DESCRIPTION
Resolve #306.

Set the 'description' for each setting inc/customizer.php.

Unlike the setting title, the description isn't automatically escaped (likely due to HTML being expected). @Misplon Are you okay with escaping the description here? I can't see a later instance where we would get to escape this without it affecting other settings. I might have missed a hook so if you know of a later hook, let me know.

The change would be:

`'description' => ! empty( $setting['description'] ) ? $setting['description'] : '',`

To:

`'description' => ! empty( $setting['description'] ) ? esc_html( $setting['description'] ) : '',`