### PR TITLE
class_exists check for SiteOrigin_Customizer_CSS_Builder typo fix

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -53,7 +53,7 @@ class SiteOrigin_Customize_Fonts_Control extends WP_Customize_Control {
 }
 endif;
 
-if(!class_exists('SiteOrigin_Customizer_CSS_Builder ')) :
+if ( !class_exists( 'SiteOrigin_Customizer_CSS_Builder' ) ) :
 /**
  * This is used for building custom CSS.
  */


### PR DESCRIPTION
[Reported here](https://siteorigin.com/thread/vantage-theme-typo-in-inc-customizer-customizer-php/)

A user was having trouble overriding SiteOrigin_Customizer_CSS_Builder due to the space in the class_exists check.