### PR TITLE
Resolve PHP warning when installing TGM plugins

### DIFF
--- a/inc/class-tgm-plugin-activation.php
+++ b/inc/class-tgm-plugin-activation.php
@@ -3506,7 +3506,7 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 								// Automatic activation strings.
 								$this->upgrader->strings['skin_upgrade_start'] = __( 'The installation and activation process is starting. This process may take a while on some hosts, so please be patient.', 'vantage' );
 								/* translators: 1: plugin name. */
-								$this->upgrader->strings['skin_update_successful'] = __( '%1$s installed and activated successfully.', 'vantage' ) . ' <a href="#" class="hide-if-no-js" onclick="%2$s"><span>' . esc_html__( 'Show Details', 'vantage' ) . '</span><span class="hidden">' . esc_html__( 'Hide Details', 'vantage' ) . '</span>.</a>';
+								$this->upgrader->strings['skin_update_successful'] = __( '%1$s done.' );
 								$this->upgrader->strings['skin_upgrade_end']       = __( 'All installations and activations have been completed.', 'vantage' );
 								/* translators: 1: plugin name, 2: action number 3: total number of actions. */
 								$this->upgrader->strings['skin_before_update_header'] = __( 'Installing and Activating Plugin %1$s (%2$d/%3$d)', 'vantage' );
@@ -3514,7 +3514,7 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 								// Default installation strings.
 								$this->upgrader->strings['skin_upgrade_start'] = __( 'The installation process is starting. This process may take a while on some hosts, so please be patient.', 'vantage' );
 								/* translators: 1: plugin name. */
-								$this->upgrader->strings['skin_update_successful'] = esc_html__( '%1$s installed successfully.', 'vantage' ) . ' <a href="#" class="hide-if-no-js" onclick="%2$s"><span>' . esc_html__( 'Show Details', 'vantage' ) . '</span><span class="hidden">' . esc_html__( 'Hide Details', 'vantage' ) . '</span>.</a>';
+								$this->upgrader->strings['skin_update_successful'] = __( '%1$s done.' );
 								$this->upgrader->strings['skin_upgrade_end']       = __( 'All installations have been completed.', 'vantage' );
 								/* translators: 1: plugin name, 2: action number 3: total number of actions. */
 								$this->upgrader->strings['skin_before_update_header'] = __( 'Installing Plugin %1$s (%2$d/%3$d)', 'vantage' );


### PR DESCRIPTION
@AlexGStapleton Can you test this out? I'm having trouble upgrading MAMP to get PHP 7.3 running. I seem to remember the TGM issue being specific to PHP 7.3, is it?

Ref for fix: https://gist.githubusercontent.com/Sharifur/cdf71a63fb402eb8f38f6fbe03e0522b/raw/02c562e959204725829d718fe20d7344e4a63e73/class-tgm-plugin-activation.php