### PR TITLE
Changed the custom logo output function

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -230,13 +230,12 @@ if ( ! function_exists( 'vantage_display_logo' ) ) :
  */
 function vantage_display_logo() {
 	$logo = siteorigin_setting( 'logo_image' );
+	if ( empty( $logo ) && function_exists( 'has_custom_logo' ) && has_custom_logo() ) {
+		$logo = get_theme_mod( 'custom_logo' );
+	}
 	$logo = apply_filters('vantage_logo_image_id', $logo);
 
 	if ( empty($logo) ) {
-		if ( function_exists( 'has_custom_logo' ) && has_custom_logo() ) {
-			the_custom_logo();
-			return;
-		}
 
 		// Just display the site title.
 		$logo_html = '<h1 class="site-title">'.get_bloginfo( 'name' ).'</h1>';


### PR DESCRIPTION
For #308.

`the_custom_logo` outputs the Site Identity logo wrapped in a link. We are already wrapping `vantage_display_logo` in a link. I’d like to remove the link from the header and or menu but don’t want to negatively impact child themes.

This commit also solves the problem of the retina logo not being used if only the Site Identity logo is used for the base logo.

**Logic:**
If Theme Settings > Logo Image is used the Site Identity won’t be displayed even if populated. The Site Identity logo will only be displayed if Theme Settings > Logo Image is empty. If the Retina Logo setting is populated, it’ll function on Retina screens regardless of the base logo in use, either Site Identity or Theme Settings logo.