### PR TITLE
Reduced the main navigation z-index

### DIFF
--- a/style.css
+++ b/style.css
@@ -850,7 +850,7 @@ body.responsive.layout-full #page-wrapper .full-container {
   background: #343538;
   position: relative;
   font-size: 0;
-  z-index: 9999;
+  z-index: 1499;
   /* Font awesome icons */
   /* General menu link styling */
 }

--- a/style.less
+++ b/style.less
@@ -725,7 +725,7 @@ body.responsive {
 	background: #343538;
 	position: relative;
 	font-size: 0;
-	z-index: 9999;
+	z-index: 1499;
 
 	/* Font awesome icons */
 	[class^="fa fa-"] {


### PR DESCRIPTION
This PR puts the main-navigation just below the WooCommerce gallery which uses a z-index of 1500. There are potential issues with a change of this nature but 9999 is very high once we consider the sticky nav interacting with gallery and lightbox plugins.