### PR TITLE
Sidebar text size setting

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -129,6 +129,14 @@ function vantage_customizer_init(){
 				'selector' => '.entry-content',
 				'property' => array('font-size'),
 			),
+			'sidebar_content_size' => array(
+				'type' => 'measurement',
+				'title' => __('Sidebar Content Size', 'vantage'),
+				'default' => 13,
+				'unit' => 'px',
+				'selector' => '#secondary .widget',
+				'property' => array('font-size'),
+			),
 			'meta_text_color' => array(
 				'type' => 'color',
 				'title' => __('Meta Text Color', 'vantage'),

--- a/style.css
+++ b/style.css
@@ -151,7 +151,7 @@ textarea {
   color: #333;
   font-family: Arial;
   font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-  line-height: 1.5em;
+  line-height: 1.5;
   font-size: 13px;
 }
 /* Links */

--- a/style.less
+++ b/style.less
@@ -27,7 +27,7 @@ textarea {
 	color: #333;
 	font-family: Arial;
 	font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-	line-height: 1.5em;
+	line-height: 1.5;
 	font-size: 13px;
 }
 


### PR DESCRIPTION
Resolves https://github.com/siteorigin/vantage/issues/327.

@AlexGStapleton The switch to unitless line-height while being broad, should benefit a lot of sites. For example, try changing the sidebar font size to <code>16px</code> and change the body line-height back to <code>1.5em</code>, then test with the body line-height at <code>1.5;</code> and see the difference.

Let me know.