### PR TITLE
Added related posts functionality

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -270,6 +270,11 @@ function vantage_theme_settings(){
 		'description' => __('Show an author box below each blog post.', 'vantage')
 	) );
 
+	$settings->add_field( 'blog', 'related_posts', 'checkbox', __( 'Related Posts', 'vantage' ), array(
+		'label' => __( 'Display', 'vantage' ),
+		'description' => __( 'Display related posts on single post pages.', 'vantage' )
+	) );
+
 	$settings->add_field('blog', 'comment_author', 'text', __("Post Author's Comments", 'vantage'), array(
 		'description' => __("Text displayed as a label next to the post author's comments.", 'vantage'),
 		'sanitize_callback' => 'wp_kses_post',
@@ -390,6 +395,7 @@ function vantage_theme_setting_defaults($defaults){
 	$defaults['blog_post_categories']                = true;
 	$defaults['blog_post_tags']                      = true;
 	$defaults['blog_author_box']                     = false;
+	$defaults['blog_related_posts']                  = false;
 	$defaults['blog_comment_author']                 = '';
 	$defaults['blog_read_more_button']               = false;
 	$defaults['blog_read_more']                      = __('Continue reading', 'vantage');

--- a/single.php
+++ b/single.php
@@ -20,9 +20,13 @@ get_header(); ?>
 			} else {
 				get_template_part( 'content', 'single' );
 			}
-		?>		
+		?>
 
 		<?php if ( siteorigin_setting( 'navigation_post_nav' ) ) vantage_content_nav( 'nav-below' ); ?>
+
+		<?php if ( ! is_attachment() && siteorigin_setting( 'blog_related_posts' ) ) {
+			vantage_related_posts( $post->ID );
+		} ?>
 
 		<?php if ( comments_open() || '0' != get_comments_number() ) : ?>
 			<?php comments_template( '', true ); ?>

--- a/style.css
+++ b/style.css
@@ -1518,7 +1518,7 @@ article.page.post-with-thumbnail-icon .entry-main {
 .related-posts-section ol li img {
   display: block;
   height: auto;
-  margin: 0 auto 15px;
+  margin: 0 auto 10px;
   max-width: 100%;
 }
 .related-posts-section ol li .related-post-title {

--- a/style.css
+++ b/style.css
@@ -1460,6 +1460,84 @@ article.page.post-with-thumbnail-icon .entry-main {
   /* 650px in standard width */
   float: right;
 }
+.related-posts-section {
+  margin-bottom: 15px;
+  overflow: auto;
+}
+.related-posts-section .related-posts {
+  border-bottom: 2px solid #555;
+  color: #444;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1em;
+  margin-bottom: 20px;
+  padding-bottom: 5px;
+}
+.related-posts-section ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+.related-posts-section ol li {
+  display: block;
+  float: left;
+  margin: 0 0 25px 0;
+  width: 31%;
+}
+@media (max-width: 768px) {
+  .related-posts-section ol li {
+    width: 100%;
+  }
+}
+.related-posts-section ol li:nth-child(3n+1) {
+  margin-right: 3.5%;
+}
+@media (max-width: 768px) {
+  .related-posts-section ol li:nth-child(3n+1) {
+    margin-right: 0;
+  }
+}
+.related-posts-section ol li:nth-child(3n+3) {
+  margin-left: 3.5%;
+}
+@media (max-width: 768px) {
+  .related-posts-section ol li:nth-child(3n+3) {
+    margin-left: 0;
+  }
+}
+.related-posts-section ol li:only-child {
+  margin: 0;
+}
+.related-posts-section ol li a {
+  display: block;
+  line-height: 0;
+  text-decoration: none;
+}
+.related-posts-section ol li img {
+  display: block;
+  height: auto;
+  margin: 0 auto 15px;
+  max-width: 100%;
+}
+.related-posts-section ol li .related-post-title {
+  color: #474747;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: normal;
+  margin: 0 0 3px;
+}
+.related-posts-section ol li .related-post-date {
+  color: #747474;
+  font-size: 13px;
+  font-weight: normal;
+  line-height: normal;
+  margin: 0;
+}
+.related-posts-section p {
+  margin-bottom: 25px;
+}
 .post-navigation,
 #image-navigation {
   margin-top: -20px;

--- a/style.less
+++ b/style.less
@@ -1310,6 +1310,93 @@ article.page{
 	}
 }
 
+.related-posts-section {
+	margin-bottom: 15px;
+	overflow: auto;
+
+	.related-posts {
+		border-bottom: 2px solid #555;
+		color: #444;
+		display: inline-block;
+		font-size: 14px;
+		font-weight: 500;
+		line-height: 1em;
+		margin-bottom: 20px;
+		padding-bottom: 5px;
+	}
+
+	ol {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		width: 100%;
+
+		li {
+			display: block;
+			float: left;
+			margin: 0 0 25px 0;
+			width: 31%;
+
+			@media (max-width: 768px) {
+				width: 100%;
+			}
+
+			&:nth-child(3n+1) {
+				margin-right: 3.5%;
+
+				@media (max-width: 768px) {
+					margin-right: 0;
+				}
+			}
+
+			&:nth-child(3n+3) {
+				margin-left: 3.5%;
+
+				@media (max-width: 768px) {
+					margin-left: 0;
+				}
+			}
+
+			&:only-child {
+				margin: 0;
+			}
+
+			a {
+				display: block;
+				line-height: 0;
+				text-decoration: none;
+			}
+
+			img {
+				display: block;
+				height: auto;
+				margin: 0 auto 15px;
+				max-width: 100%;
+			}
+
+			.related-post-title {
+				color: #474747;
+				font-size: 14px;
+				font-weight: 500;
+				line-height: normal;
+				margin: 0 0 3px;
+			}
+
+			.related-post-date {
+				color: #747474;
+				font-size: 13px;
+				font-weight: normal;
+				line-height: normal;
+				margin: 0;
+			}
+		}
+	}
+
+	p {
+		margin-bottom: 25px;
+	}
+}
+
 .post-navigation,
 #image-navigation{
 	margin-top: -20px;

--- a/style.less
+++ b/style.less
@@ -1370,7 +1370,7 @@ article.page{
 			img {
 				display: block;
 				height: auto;
-				margin: 0 auto 15px;
+				margin: 0 auto 10px;
 				max-width: 100%;
 			}
 


### PR DESCRIPTION
Resolves https://github.com/siteorigin/vantage/issues/329.

For some reason, when Jetpack Related Posts is activated, the Jetpack Related Posts setting to add the section heading is inverted, when it's off, the heading displays. I'm not quite sure why that is. Otherwise, I think the PR is ready. Let me know if you find anything.