### PR TITLE
Small input field styling improvements

### DIFF
--- a/less/widgets.less
+++ b/less/widgets.less
@@ -17,7 +17,6 @@
 
 .widget .searchform input {
 	width: 100%;
-	padding: 5px;
 	outline: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -370,55 +370,78 @@ input[type="radio"] {
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   padding: 0;
-  /* Addresses excess padding in IE8/9 */
 }
 input[type="search"] {
-  /* Addresses appearance set to searchfield in S5, Chrome */
-  -webkit-appearance: textfield;
-  /* Addresses box sizing set to border-box in S5, Chrome (include -moz to future-proof) */
   -ms-box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
+  -webkit-appearance: textfield;
 }
 input[type="search"]::-webkit-search-decoration {
-  /* Corrects inner padding displayed oddly in S5, Chrome on OSX */
   -webkit-appearance: none;
 }
 button::-moz-focus-inner,
 input::-moz-focus-inner {
-  /* Corrects inner padding and border displayed oddly in FF3/4 www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/ */
   border: 0;
   padding: 0;
 }
-input[type=text],
-input[type=email],
-input[type=password],
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
 textarea {
-  -ms-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-  color: #666;
   border: 1px solid #ccc;
   border-radius: 3px;
+  box-sizing: border-box;
+  color: #666;
+  font-weight: normal;
+  line-height: normal;
+  outline: none;
+  padding: 9px 12px;
+  max-width: 100%;
+  -webkit-appearance: none;
 }
-input[type=text]:focus,
-input[type=email]:focus,
-input[type=password]:focus,
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
 textarea:focus {
   color: #111;
 }
-input[type=text],
-input[type=email],
-input[type=password] {
-  padding: 3px;
+input[type="checkbox"] {
+  margin-right: 2px;
+}
+select {
+  border: 1px solid #ccc;
+  max-width: 100%;
 }
 textarea {
-  /* Removes default vertical scrollbar in IE6/7/8/9 */
   overflow: auto;
-  /* Improves readability and alignment in all browsers */
   vertical-align: top;
+  width: 100%;
 }
 /* Alignment */
 .alignleft {
@@ -1367,12 +1390,12 @@ article.page .author-box .box-content .box-title h3 {
   font-size: 1.25em;
   line-height: 1.1em;
   font-weight: 500;
-  margin: .6em 0 0;
+  margin: 0.6em 0 0;
 }
 article.post .author-box .box-content .author-posts a,
 article.page .author-box .box-content .author-posts a {
   color: #777;
-  font-size: .9em;
+  font-size: 0.9em;
   text-decoration: none;
 }
 article.post .author-box .box-content .author-posts a:hover,
@@ -2574,7 +2597,6 @@ html[xmlns] .slides {
 }
 .widget .searchform input {
   width: 100%;
-  padding: 5px;
   outline: none;
 }
 .textwidget p:first-child {

--- a/style.less
+++ b/style.less
@@ -197,58 +197,70 @@ input[type="submit"]{
 input[type="checkbox"],
 input[type="radio"] {
 	.box-sizing(border-box);
-	padding: 0;
-	/* Addresses excess padding in IE8/9 */
+	padding: 0; // Addresses excess padding in IE8/9.
 }
 
 input[type="search"] {
-	/* Addresses appearance set to searchfield in S5, Chrome */
-	-webkit-appearance: textfield;
-
-	/* Addresses box sizing set to border-box in S5, Chrome (include -moz to future-proof) */
-	.box-sizing(border-box);
+	.box-sizing(border-box); // Addresses box sizing set to border-box in S5, Chrome (include -moz to future-proof).
+	-webkit-appearance: textfield; // Addresses appearance set to searchfield in S5, Chrome.
 }
 
 input[type="search"]::-webkit-search-decoration {
-	/* Corrects inner padding displayed oddly in S5, Chrome on OSX */
-	-webkit-appearance: none;
+	-webkit-appearance: none; // Corrects inner padding displayed oddly in S5, Chrome on OSX.
 }
 
 button::-moz-focus-inner,
 input::-moz-focus-inner {
-	/* Corrects inner padding and border displayed oddly in FF3/4 www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/ */
+	// Corrects inner padding and border displayed oddly in FF3/4 www.sitepen.com/blog/2008/05/14/the-devils-in-the-details-fixing-dojos-toolbar-buttons/.
 	border: 0;
 	padding: 0;
 }
 
-input[type=text],
-input[type=email],
-input[type=password],
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
 textarea {
-	.box-sizing(border-box);
-	color: #666;
 	border: 1px solid #ccc;
 	border-radius: 3px;
+	box-sizing: border-box;
+	color: #666;
+	font-weight: normal; 
+	line-height: normal;
+	outline: none;
+	padding: 9px 12px;
+	max-width: 100%;
+	-webkit-appearance: none;
+
+	&:focus {
+		color: #111;
+	}
 }
 
-input[type=text]:focus,
-input[type=email]:focus,
-input[type=password]:focus,
-textarea:focus {
-	color: #111;
+input[type="checkbox"] {
+	margin-right: 2px; 
 }
 
-input[type=text],
-input[type=email],
-input[type=password] {
-	padding: 3px;
+select {
+	border: 1px solid #ccc;
+	max-width: 100%;
 }
 
 textarea {
-	/* Removes default vertical scrollbar in IE6/7/8/9 */
-	overflow: auto;
-	/* Improves readability and alignment in all browsers */
-	vertical-align: top;
+	overflow: auto; // Removes default vertical scrollbar in IE6/7/8/9.
+	vertical-align: top; // Improves readability and alignment in all browsers.
+	width: 100%;
 }
 
 /* Alignment */


### PR DESCRIPTION
Main issue I wanted to resolve was the default field height not being enough.

<img width="844" alt="Testing_–_SiteOrigin" src="https://user-images.githubusercontent.com/789159/72254916-13ed9200-360e-11ea-8773-7aeac59763a8.png">

I've left the legacy CSS in place.