### PR TITLE
Removed overflow-y scroll

### DIFF
--- a/less/reset.less
+++ b/less/reset.less
@@ -72,9 +72,6 @@ html {
     font-size: 62.5%;
     /* Corrects text resizing oddly in IE6/7 when body font-size is set using em units http://clagnut.com/blog/348/#c790 */
 
-    overflow-y: scroll;
-    /* Keeps page centred in all browsers regardless of content height */
-
     -webkit-text-size-adjust: 100%;
     /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
 


### PR DESCRIPTION
`overflow-y: scroll;` breaks the disable scrolling setting used by lightboxes.

Resolves #349.

For comparison, here is what’s in _s html reset currently https://github.com/Automattic/_s/blob/master/sass/_normalize.scss#L11-L14.