### PR TITLE
Replaced is_shop() with is_woocommerce()

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -42,7 +42,8 @@ function vantage_body_classes( $classes ) {
 
 	$is_full_width_template = is_page_template( 'templates/template-full.php' ) || is_page_template( 'templates/template-full-notitle.php' );
 	if ( ! $is_full_width_template ) {
-		$wc_shop_sidebar = vantage_is_woocommerce_active() && is_shop() && is_active_sidebar( 'shop' );
+		// Is WooCommerce active, is the Shop sidebar populated, are we viewing a WooCommerce page?
+		$wc_shop_sidebar = vantage_is_woocommerce_active() && is_active_sidebar( 'shop' ) && is_woocommerce();
 		if ( ! is_active_sidebar( 'sidebar-1' ) && ! $wc_shop_sidebar ) {
 			$classes[] = 'no-sidebar';
 		}


### PR DESCRIPTION
To view the issue this PR resolves:

1. Make sure the default sidebar widget area is empty.
2. Add a widget to the Shop widget area.
3. View a shop category page, note the widget are under the main content area because `no-sidebar` is being outputted as a body class.