### PR TITLE
Block Editor: Resolve Row Background Saving Issue

### DIFF
--- a/inc/panels.php
+++ b/inc/panels.php
@@ -218,8 +218,20 @@ function vantage_panels_row_style_fields($fields) {
 	) {
 		return $fields;
 	}
+
 	// Detect if this is a custom home page builder and if has legacy row styles enabled or not
 	if ( ( ! empty( $_REQUEST['page'] ) && $_REQUEST['page'] === 'so_panels_home_page' && get_post_meta( intval( get_option('siteorigin_panels_home_page_id') ), 'vantage_panels_no_legacy', true ) === 'true' ) ) {
+		return $fields;
+	}
+
+	// Are we trying to generate a block preview?
+	if (
+		! empty( $_POST['action'] ) &&
+		(
+			$_POST['action'] == 'so_panels_layout_block_preview' ||
+			$_POST['action'] == 'so_panels_builder_content_json'
+		)
+	) {
 		return $fields;
 	}
 


### PR DESCRIPTION
This PR resolves an issue that occurs while using the Block Editor. The Legacy Theme Settings code applies even though the meta check passes. This happens due the Block Editor preview and content generation changes not relying on the page id and being block specific. This PR checks for those actions and returns the default `$fields`. An additional post meta check isn't required for those Ajax requests as legacy fields will never be present on a Block Editor powered page.

To test this PR please activate Vantage and then open/create a Block Editor powered page. Add a SiteOrigin Layout Block and add an Archives widget. Open the Row and set a Background Color and Background Image. Wait for the block generation to finish and then save. Reload and open the row. The Background Image won't be set. 