### PR TITLE
Revert "JQuery: Update deprecated .bind() usage"

### DIFF
--- a/inc/customizer/js/admin.js
+++ b/inc/customizer/js/admin.js
@@ -1,7 +1,7 @@
 
 /* globals jQuery, wp, soCustomizeAdmin, confirm */
 
-wp.customize.on( 'ready', function( value ){
+wp.customize.bind( 'ready', function( value ){
     var $ = jQuery;
 
     var button = null;

--- a/inc/customizer/js/live-customizer.js
+++ b/inc/customizer/js/live-customizer.js
@@ -22,7 +22,7 @@ jQuery(function($){
             switch( el.type ) {
                 case 'color' :
                     wp.customize( id, function( value ) {
-                        value.on( function( newval ) {
+                        value.bind( function( newval ) {
                             if(typeof el.property === 'string') {
                                 el.property = [el.property];
                             }
@@ -36,7 +36,7 @@ jQuery(function($){
 
                 case 'measurement' :
                     wp.customize( id, function( value ) {
-                        value.on( function( newval ) {
+                        value.bind( function( newval ) {
                             var val = newval;
                             if(typeof el.unit !== 'undefined') {
                                 val = val + el.unit;


### PR DESCRIPTION
This reverts commit 960e3c0f4215b85f54d52b07dab27f83101c5937. Upon further inspection, these are valid uses of the JavaScript [bind()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind) and not jQuery [$.bind()](https://api.jquery.com/bind/);