### PR TITLE
Resolve PHP 8 Deprecated Notice

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -327,7 +327,7 @@ class SiteOrigin_Customizer_Helper {
 	private $sections;
 	private $defaults;
 
-	function __construct($settings = array(), $sections = array(), $theme, $root_url = false, $make_single = true){
+	function __construct($settings = array(), $sections = array(), $theme = 'generic', $root_url = false, $make_single = true){
 		// Give child themes a chance to filter this.
 		$this->theme = $theme;
 		$this->defaults = array();


### PR DESCRIPTION
[Related](https://siteorigin.com/thread/debug-log-with-php-8-and-pagebuilder-with-vantage-theme/#comment-586699) 

This PR resolves:

`[29-Jan-2021 17:53:38 UTC] PHP Deprecated: Required parameter $theme follows optional parameter $settings in /var/www/vhosts/DOMAIN/httpdocs/wp-content/themes/vantage/inc/customizer/customizer.php on line 330`

$theme is used in filters so I set the default to generic. $theme is _always_ set so it's unlikely `generic` will ever be used.