### PR TITLE
Customizer Fonts: Prevent invalid font property and duplicate

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -177,13 +177,16 @@ class SiteOrigin_Customizer_CSS_Builder {
 		}
 
 		$this->add_css( $selector, 'font-family', $family );
-		if ( $variant != 400 ) $this->add_css( $selector, 'font-weight', $variant );
-
-		$this->fonts[ ] = $font;
-
-		if ( !empty( $variant ) ) {
-			if ( $variant == 'regular' ) $variant = '400';
-			$this->css[ $selector ][ ] = 'font-weight: ' . $variant;
+		if ( ! empty( $variant ) ) {
+			if ( $variant != 400 && $variant != 'regular' ) {
+				if ( ! is_numeric( $variant ) ) {
+					$variant = filter_var( $variant, FILTER_SANITIZE_NUMBER_INT );
+					$this->add_css( $selector, 'font-style', 'italic' );
+				}
+				$this->add_css( $selector, 'font-weight', $variant );
+			} else {
+				$this->add_css( $selector, 'font-weight', 400 );
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR prevents an issue where an invalid font-weight will be used if an italic font is selected. It'll also prevent duplicate font-weight.

<img width="210" alt="2021-04-14_23-54-44-1456" src="https://user-images.githubusercontent.com/17275120/114723380-f6155c80-9d7d-11eb-8495-c1fe5582181a.png">
