### PR TITLE
Only setup FitVids if Enabled in Theme Settings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -354,6 +354,12 @@ function vantage_scripts() {
 
 	if ( siteorigin_setting( 'layout_fitvids' ) ) {
 		wp_enqueue_script( 'jquery-fitvids' , get_template_directory_uri() . '/js/jquery.fitvids' . SITEORIGIN_THEME_JS_PREFIX . '.js' , array('jquery'), '1.0', $in_footer );
+		wp_localize_script(
+			'vantage-main',
+			'vantage', array(
+				'fitvids' => true,
+			)
+		);
 	}
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {

--- a/js/jquery.theme-main.js
+++ b/js/jquery.theme-main.js
@@ -13,7 +13,7 @@ jQuery ( function( $ ) {
 	} );
 
 	// Setup FitVids for entry content, video post format, Panels, WooCommerce pages, masthead widget area and the header sidebar.
-	if ( typeof $.fn.fitVids !== 'undefined' ) {
+	if ( typeof $.fn.fitVids !== 'undefined' && typeof vantage !== 'undefined' && typeof vantage.fitvids ) {
 		$( '.entry-content, .entry-content .panel, .entry-video, .woocommerce #main, #masthead-widgets, #header-sidebar' ).fitVids( { ignore: '.tableauViz' } );
 	}
 


### PR DESCRIPTION
Resolve https://github.com/siteorigin/vantage/issues/389

To test this:
- Install [FitVids for WordPress](https://wordpress.org/plugins/fitvids-for-wordpress/)
- Open js/jquery.theme-main.js and find:

`$( '.entry-content, .entry-content .panel, .entry-video, .woocommerce #main, #masthead-widgets, #header-sidebar' ).fitVids( { ignore: '.tableauViz' } );`

Add the following to the line prior:

`alert( 123 );`

- Disable FitVids in the theme settings (Theme Settings > Layout and untick Use FitVids). Confirm that the alert still happens.
- Apply PR and re-apply the above JS modification.
- Confirm alert doesn't happen, and then re-enable FitVids in theme settings. Confirm alert happens after FitVids is enabled in theme settings.