### PR TITLE
Accessibility: Move Search to help with tab order

### DIFF
--- a/parts/menu.php
+++ b/parts/menu.php
@@ -32,17 +32,18 @@ $logo_in_menu = siteorigin_setting( 'layout_masthead' ) == 'logo-in-menu';
 				<?php endif; ?>
 			</div>
 		<?php endif; ?>
-		<?php if ( siteorigin_setting('navigation_menu_search') && ! $max_mega_menu_active ) : ?>
-			<div id="search-icon">
-				<div id="search-icon-icon" tabindex="0" aria-label="<?php _e( 'Open the search', 'vantage' ); ?>"><?php echo vantage_display_icon( 'search' ); ?></div>
-				<?php get_search_form(); ?>
-			</div>
-		<?php endif; ?>
 
 		<?php if ( $ubermenu_active ): ?>
 			<?php ubermenu( 'main' , array( 'theme_location' => 'primary' ) ); ?>
 		<?php else: ?>
 			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'link_before' => '<span class="icon"></span>' ) ); ?>
+		<?php endif; ?>
+
+		<?php if ( siteorigin_setting('navigation_menu_search') && ! $max_mega_menu_active ) : ?>
+			<div id="search-icon">
+				<div id="search-icon-icon" tabindex="0" aria-label="<?php _e( 'Open the search', 'vantage' ); ?>"><?php echo vantage_display_icon( 'search' ); ?></div>
+				<?php get_search_form(); ?>
+			</div>
 		<?php endif; ?>
 	</div>
 </nav><!-- .site-navigation .main-navigation -->


### PR DESCRIPTION
Resolve https://github.com/siteorigin/vantage/issues/396

This PR will move the search after the menu. This won't result in any visible differences but it'll ensure the menu is tabbed to before the search.