### PR TITLE
WC: Page Settings Single Product Page Support 

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -84,6 +84,11 @@ function vantage_setup() {
 	add_theme_support( 'wc-product-gallery-lightbox' );
 	add_theme_support( 'wc-product-gallery-slider' );
 
+	// Add Page Settings support for WooCommerce Product pages.
+	if ( vantage_is_woocommerce_active() ) {
+		add_post_type_support( 'product', 'so-page-settings' );
+	}
+
 	set_post_thumbnail_size( 720, 380, true );
 	add_image_size( 'vantage-thumbnail-no-sidebar', 1080, 380, true );
 	add_image_size( 'vantage-slide', 960, 480, true );

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -518,12 +518,14 @@ function vantage_page_settings( $settings, $type, $id ){
 		);
 	}
 
-	$settings['page_title'] = array(
-		'type'           => 'checkbox',
-		'label'          => __( 'Page Title', 'vantage' ),
-		'checkbox_label' => __( 'display', 'vantage' ),
-		'description'    => __( 'Display the page title on this page.', 'vantage' )
-	);
+	if ( $type != 'product' ) {
+		$settings['page_title'] = array(
+			'type'           => 'checkbox',
+			'label'          => __( 'Page Title', 'vantage' ),
+			'checkbox_label' => __( 'display', 'vantage' ),
+			'description'    => __( 'Display the page title on this page.', 'vantage' )
+		);
+	}
 
 	$settings['masthead_margin'] = array(
 		'type'           => 'checkbox',
@@ -565,11 +567,15 @@ if ( ! function_exists( 'vantage_setup_page_setting_defaults' ) ) :
 function vantage_setup_page_setting_defaults( $defaults, $type, $id ){
 	// All the basic default settings
 	$defaults['layout']              = 'default';
-	$defaults['page_title']          = true;
 	$defaults['masthead_margin']     = true;
 	$defaults['footer_margin']       = true;
 	$defaults['hide_masthead']       = false;
 	$defaults['hide_footer_widgets'] = false;
+
+	// Certain basic defaults don't apply for WooCommerce product pages.
+	if ( $type != 'product' ) {
+		$defaults['page_title'] = true;
+	}
 
 	// Defaults for page only settings
 	if( $type == 'post' ) $post = get_post( $id );


### PR DESCRIPTION
Requires https://github.com/siteorigin/settings/pull/75

This PR enables the Page Settings metabox for WC Single Products Page. I've run a few tests and the only setting that didn't appear to work was the Page Title setting so I've disabled that setting.