### PR TITLE
Circle Icon Widget: Resolve Icon Color Notice

### DIFF
--- a/inc/widgets.php
+++ b/inc/widgets.php
@@ -72,7 +72,7 @@ class Vantage_CircleIcon_Widget extends WP_Widget {
 					<a href="<?php echo esc_url($instance['more_url']) ?>" class="link-icon" <?php echo $target ?>><?php endif; ?>
 					<div class="circle-icon<?php echo esc_attr( $icon_class ); ?>" <?php echo $icon_styles; ?>>
 						<?php if ( ! empty( $icon ) ): ?>
-							<div class="<?php echo esc_attr( $icon ); esc_attr( $icon_class ); ?>" <?php echo $icon_color; ?>></div>
+							<div class="<?php echo esc_attr( $icon ); esc_attr( $icon_class ); ?>" <?php echo ! empty( $icon_color ) ? $icon_color : ''; ?>></div>
 						<?php endif; ?>
 					</div> 
 					<?php if(!empty($instance['more_url']) && !empty($instance['all_linkable'])) : ?></a><?php endif; ?>


### PR DESCRIPTION
[Reported here](https://themes.trac.wordpress.org/ticket/116605#comment:2)

This PR resolve the following notice by the WordPress Theme Check Action:

` "/" (via: home-panels.php) contains PHP errors: Notice: Undefined variable: icon_color in wp-content/themes/vantage/inc/widgets.php on line 75`

This PR can be replicated by adding a Circle Icon widget to a page without setting an icon color - no setting adjustments are required.