### PR TITLE
WC: Mini Cart

### DIFF
--- a/css/woocommerce.css
+++ b/css/woocommerce.css
@@ -422,3 +422,126 @@
 .entry-content ul .wc-block-grid__product {
   margin-left: 0;
 }
+/* WooCommerce Mini Cart */
+.site-header .shopping-cart {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+.site-header .shopping-cart:hover .shopping-cart-dropdown {
+  display: block;
+}
+.site-header .shopping-cart li {
+  font-size: initial;
+  text-transform: none;
+}
+.site-header .shopping-cart li:first-of-type {
+  padding: 0;
+}
+.site-header .shopping-cart,
+.site-header .shopping-cart li,
+.site-header .shopping-cart .shopping-cart-link {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+}
+.site-header .shopping-cart-text {
+  display: none;
+}
+.site-header .shopping-cart-link {
+  padding: 0 19px;
+}
+.site-header .shopping-cart-link svg {
+  display: inline-block;
+  fill: #fff;
+  height: 18.84px;
+  position: relative;
+  vertical-align: text-bottom;
+  width: 20px;
+}
+.site-header .shopping-cart-link .shopping-cart-count {
+  background: #f14e4e;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 9px;
+  height: 18px;
+  line-height: 18px;
+  min-width: 18px;
+  padding-left: 1px;
+  position: absolute;
+  right: 27%;
+  text-align: center;
+  top: 4px;
+  transition: 0.3s;
+}
+.site-header .shopping-cart-link:hover .shopping-cart-count {
+  background: rgba(241, 78, 78, 0.8);
+}
+.site-header .shopping-cart-link:hover .shopping-cart-text {
+  color: #626262;
+}
+.site-header .shopping-cart-dropdown {
+  background: #343538;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.16);
+  display: none;
+  width: 300px;
+  z-index: 99999;
+}
+.site-header .shopping-cart-dropdown .widget {
+  color: #fff;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+.site-header .shopping-cart-dropdown .widget li {
+  overflow: initial;
+}
+.site-header .shopping-cart-dropdown .widget li:hover > a {
+  background: transparent;
+  color: #fff;
+}
+.site-header .shopping-cart-dropdown .widget .product_list_widget {
+  background: transparent;
+  margin-right: 0;
+  opacity: 1;
+  position: static;
+  visibility: visible;
+}
+.site-header .shopping-cart-dropdown .widget .product_list_widget li {
+  padding: 20px;
+}
+.site-header .shopping-cart-dropdown .widget .product_list_widget li img {
+  margin: 0;
+  margin-right: 10px;
+  width: 70px;
+}
+.site-header .shopping-cart-dropdown .widget .product_list_widget li a {
+  padding-left: 0;
+  width: auto;
+}
+.site-header .shopping-cart-dropdown .widget .product_list_widget li a.remove {
+  left: initial;
+  right: 20px;
+  top: 40%;
+}
+.site-header .shopping-cart-dropdown .widget .widget_shopping_cart .cart_list .mini_cart_item a {
+  margin: 0;
+}
+.site-header .shopping-cart-dropdown .widget .blockOverlay[style] {
+  background-color: #fff !important;
+}
+.site-header .shopping-cart-dropdown .widget .woocommerce-mini-cart__empty-message {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  text-transform: none;
+}
+.site-header .shopping-cart-dropdown .widget .woocommerce-mini-cart__total,
+.site-header .shopping-cart-dropdown .widget .woocommerce-mini-cart__buttons {
+  margin: 20px;
+}
+.site-header .shopping-cart-dropdown .widget .woocommerce-mini-cart__buttons {
+  transition: none;
+  margin-bottom: 0;
+}

--- a/css/woocommerce.css
+++ b/css/woocommerce.css
@@ -545,3 +545,11 @@
   transition: none;
   margin-bottom: 0;
 }
+@media (max-width: 1447px) {
+  .site-header .shopping-cart:hover .shopping-cart-dropdown {
+    left: -240.5px;
+  }
+  .has-menu-search .main-navigation ul.shopping-cart-dropdown {
+    left: -183.5px;
+  }
+}

--- a/functions.php
+++ b/functions.php
@@ -228,6 +228,40 @@ function vantage_is_woocommerce_active() {
 }
 endif;
 
+if ( ! function_exists( 'vantage_woocommerce_mini_cart' ) ) :
+/**
+ * Display the WooCommerce mini cart.
+ */
+function vantage_woocommerce_mini_cart() {
+	if (
+		apply_filters( 'vantage_display_mini_cart', ! ( is_cart() || is_checkout() ) )
+	) :
+		global $woocommerce;
+		?>
+		<ul class="shopping-cart">
+			<li>
+				<a class="shopping-cart-link" href="<?php echo esc_url( wc_get_cart_url() ); ?>" title="<?php esc_attr_e( 'View shopping cart', 'vantage' ); ?>">
+					<span class="screen-reader-text"><?php esc_html_e( 'View shopping cart', 'vantage' ); ?></span>
+					<?php vantage_display_icon( 'mini_cart' ); ?>
+					<span class="shopping-cart-text"><?php esc_html_e( 'View Cart', 'vantage' ); ?></span>
+					<span class="shopping-cart-count"><?php echo WC()->cart->cart_contents_count; ?></span>
+				</a>
+				<ul class="shopping-cart-dropdown" id="cart-drop">
+					<?php 
+					$instance = array(
+						'title' => '',
+					);
+
+					the_widget( 'WC_Widget_Cart', $instance );
+					?>
+				</ul>
+			</li>
+		</ul>
+	<?php endif; ?>
+<?php
+}
+endif;
+
 if ( ! function_exists( 'vantage_register_custom_background' ) ) :
 /**
  * Setup the WordPress core custom background feature.

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -274,7 +274,7 @@ function vantage_customizer_init(){
 				'type' => 'color',
 				'title' => __('Background', 'vantage'),
 				'default' => '#343538',
-				'selector' => '.main-navigation',
+				'selector' => '.main-navigation, .site-header .shopping-cart-dropdown',
 				'property' => 'background-color',
 			),
 			'text' => array(

--- a/inc/mobilenav/mobilenav.php
+++ b/inc/mobilenav/mobilenav.php
@@ -97,7 +97,7 @@ function siteorigin_mobilenav_nav_menu_css(){
 	if ( $mobile_resolution != 0 ) : ?>
 		<style type="text/css">
 			.so-mobilenav-mobile + * { display: none; }
-			@media screen and (max-width: <?php echo intval($mobile_resolution) ?>px) { .so-mobilenav-mobile + * { display: block; } .so-mobilenav-standard + * { display: none; } .site-navigation #search-icon { display: none; } }
+			@media screen and (max-width: <?php echo intval($mobile_resolution) ?>px) { .so-mobilenav-mobile + * { display: block; } .so-mobilenav-standard + * { display: none; } .site-header .shopping-cart, .site-navigation #search-icon { display: none; } }
 		</style>
 	<?php else : ?>
 		<style type="text/css">

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -23,6 +23,7 @@ function vantage_theme_settings(){
 	$settings->add_section( 'icons', __( 'Icons', 'vantage' ) );
 	$settings->add_section( 'blog', __( 'Blog', 'vantage' ) );
 	$settings->add_section( 'social', __( 'Social', 'vantage' ) );
+	$settings->add_section( 'woocommerce', __( 'WooCommerce', 'vantage' ) );
 	$settings->add_section( 'general', __( 'General', 'vantage' ) );
 
 	/**
@@ -314,6 +315,19 @@ function vantage_theme_settings(){
 	));
 
 	/**
+	 * WooCommerce Settings
+	 */
+	if ( vantage_is_woocommerce_active() ) {
+		$settings->add_field( 'woocommerce', 'mini_cart', 'checkbox', __( 'Mini Cart in Menu', 'vantage' ), array(
+			'description' => __( 'Display a mini cart in the main menu.', 'vantage' )
+		) );
+
+		$settings->add_field( 'woocommerce', 'mini_cart_icon', 'media', __( 'Mini Cart Icon', 'vantage' ), array(
+	 		'choose' => __( 'Choose Image', 'vantage' ),
+	 		'update' => __( 'Set Logo', 'vantage' )
+	 	) );
+	}
+	/**
 	 * General Settings
 	 */
 
@@ -405,6 +419,9 @@ function vantage_theme_setting_defaults($defaults){
 	$defaults['blog_grid_column_count']              = 4;
 
 	$defaults['social_ajax_comments']                = true;
+
+	$defaults['woocommerce_mini_cart']               = false;
+	$defaults['woocommerce_mini_cart_icon']          = false;
 
 	$defaults['general_site_info_text']              = '';
 	$defaults['general_privacy_policy_link']         = false;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -593,6 +593,18 @@ function vantage_display_icon( $type ) {
 			endif;
 			break;
 
+		case 'mini_cart':
+			if ( siteorigin_setting( 'woocommerce_mini_cart_icon' ) ) :
+				echo wp_get_attachment_image( siteorigin_setting( 'woocommerce_mini_cart_icon' ), 'full', false, '' );
+			else :
+				?>
+					<svg xmlns="http://www.w3.org/2000/svg" width="16.97" height="16" viewBox="0 0 16.97 16">
+						<path id="cart" class="cls-1" d="M1313.9,36.289l-2.01,6a0.994,0.994,0,0,1-.95.711h-7.35a0.962,0.962,0,0,1-.35-0.072c-0.04-.015-0.07-0.037-0.11-0.056a0.969,0.969,0,0,1-.19-0.131,0.644,0.644,0,0,1-.1-0.1c-0.04-.056-0.08-0.117-0.12-0.184-0.02-.043-0.04-0.084-0.06-0.13-0.01-.024-0.02-0.043-0.03-0.068l-2.09-7.07A1.779,1.779,0,0,0,1298.98,34h-0.99a1,1,0,0,1,0-2h0.99a3.773,3.773,0,0,1,3.49,2.669l0.1,0.332h10.38a1,1,0,0,1,.8.4A0.969,0.969,0,0,1,1313.9,36.289Zm-10.74.71,1.18,4h5.85l1.41-4h-8.44Zm0.81,7a2,2,0,1,1-2,2A2,2,0,0,1,1303.97,44Zm6.99,0a2,2,0,1,1-2,2A2,2,0,0,1,1310.96,44Z" transform="translate(-1297 -32)"/>
+					</svg>
+				<?php
+			endif;
+			break;
+
 	}
 }
 endif;

--- a/less/css/woocommerce.less
+++ b/less/css/woocommerce.less
@@ -599,3 +599,12 @@
 	}
 }
 
+
+@media (max-width: 1447px) {
+	.site-header .shopping-cart:hover .shopping-cart-dropdown {
+	  left: -240.5px;
+	}
+	.has-menu-search .main-navigation ul.shopping-cart-dropdown {
+	  left: -183.5px;
+	}
+}

--- a/less/css/woocommerce.less
+++ b/less/css/woocommerce.less
@@ -460,3 +460,142 @@
 .entry-content ul .wc-block-grid__product {
 	margin-left: 0;
 }
+
+/* WooCommerce Mini Cart */
+.site-header .shopping-cart {
+	position: absolute;
+	right: 0;
+	top: 0;
+
+	&:hover .shopping-cart-dropdown {
+		display: block;
+	}
+
+	li {
+		font-size: initial;
+		text-transform: none;
+		&:first-of-type {
+			padding: 0;
+		}
+	}
+
+	&,
+	& li,
+	.shopping-cart-link {
+		align-items: center;
+		display: flex;
+		height: 100%;
+		justify-content: center;
+	}
+
+
+	&-text {
+			display: none;
+	}
+
+	&-link {
+		padding: 0 19px;
+		svg {
+			display: inline-block;
+			fill: #fff;
+			height: 18.84px;
+			position: relative;
+			vertical-align: text-bottom;
+			width: 20px;
+		}
+
+		.shopping-cart-count {
+			background: #f14e4e;
+			border-radius: 50%;
+			color: #fff;
+			font-size: 9px;
+			height: 18px;
+			line-height: 18px;
+			min-width: 18px;
+			padding-left: 1px;
+			position: absolute;
+			right: 27%;
+			text-align: center;
+			top: 4px;
+			transition: .3s;
+		}
+
+		&:hover {
+			.shopping-cart-count {
+				background: rgba(241, 78, 78, 0.8);
+			}
+			.shopping-cart-text {
+				color: #626262;
+			}
+		}
+	}
+
+
+	&-dropdown {
+		background: #343538;
+		box-shadow: 0 0 12px rgba(0, 0, 0, 0.16);
+		display: none;
+		width: 300px;
+		z-index: 99999;
+
+		.widget {
+			color: #fff;
+			max-height: 70vh;
+			overflow-y: auto;
+			li {
+				overflow: initial;
+				&:hover > a {
+					background: transparent;
+					color: #fff;
+				}
+			}
+			.product_list_widget {
+				background: transparent;
+				margin-right: 0;
+				opacity: 1;
+				position: static;
+				visibility: visible;
+				li {
+					padding: 20px;
+					img {
+						margin: 0;
+						margin-right: 10px;
+						width: 70px;
+					}
+					a {
+						padding-left: 0;
+						width: auto;
+						&.remove {
+							left: initial;
+							right: 20px;
+							top: 40%;
+						}
+					}
+				}
+			}
+			.widget_shopping_cart .cart_list .mini_cart_item a {
+					margin: 0;
+			}
+			.blockOverlay[style] {
+				background-color: #fff !important;
+			}
+			.woocommerce-mini-cart__empty-message {
+				display: block;
+				font-size: 14px;
+				font-weight: 600;
+				margin: 0;
+				text-transform: none;
+			}
+			.woocommerce-mini-cart__total,
+			.woocommerce-mini-cart__buttons {
+					margin: 20px;
+			}
+
+			.woocommerce-mini-cart__buttons {
+				transition: none;
+				margin-bottom: 0;
+			}
+		}
+	}
+}
+

--- a/parts/menu.php
+++ b/parts/menu.php
@@ -40,6 +40,10 @@ $logo_in_menu = siteorigin_setting( 'layout_masthead' ) == 'logo-in-menu';
 			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'link_before' => '<span class="icon"></span>' ) ); ?>
 		<?php endif; ?>
 
+		<?php if ( siteorigin_setting ( 'woocommerce_mini_cart' ) && vantage_is_woocommerce_active() ) : ?>
+			<?php vantage_woocommerce_mini_cart(); ?>
+		<?php endif; ?>
+
 		<?php if ( siteorigin_setting('navigation_menu_search') && ! $max_mega_menu_active ) : ?>
 			<div id="search-icon">
 				<div id="search-icon-icon" tabindex="0" aria-label="<?php _e( 'Open the search', 'vantage' ); ?>"><?php echo vantage_display_icon( 'search' ); ?></div>


### PR DESCRIPTION
Resolve https://github.com/siteorigin/vantage/issues/228

This PR allows users to enable the mini-cart in the header by navigating to **Appearance > Customize,** **Theme Settings > WooCommerce** and enabling it. It includes a method of setting a custom icon.

Possible improvements:
- Dedicated colour settings.
- Dedicated setting to adjust button colours