### PR TITLE
Add Websafe Filters

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -6,11 +6,10 @@ if ( class_exists( 'WP_Customize_Control' ) && !class_exists('SiteOrigin_Customi
  */
 class SiteOrigin_Customize_Fonts_Control extends WP_Customize_Control {
 	function __construct( $manager, $id, $args = array() ) {
-		// Let other themes and plugins process the web fonts array
 		$google_web_fonts = include ( dirname(__FILE__) . '/google-fonts.php' );
 
 		// Add the default fonts
-		$choices = array(
+		$choices = apply_filters( 'vantage_websafe', array(
 			'Arial' => 'Arial',
 			'Courier New' => 'Courier New',
 			'Georgia' => 'Georgia',
@@ -19,7 +18,7 @@ class SiteOrigin_Customize_Fonts_Control extends WP_Customize_Control {
 			'Tahoma' => 'Tahoma',
 			'Trebuchet MS' => 'Trebuchet MS',
 			'Verdana' => 'Verdana',
-		);
+		) );
 
 		foreach ( $google_web_fonts as $font => $variants ) {
 			foreach ( $variants as $variant ) {
@@ -64,23 +63,24 @@ class SiteOrigin_Customizer_CSS_Builder {
 	private $raw_css;
 	private $fonts;
 	private $defaults;
+	private $web_safe;
 
 	// These are web safe fonts
-	static $web_safe = array(
-		'Arial' => 'Arial, Helvetica, sans-serif',
-		'Courier New' => 'Courier, mono',
-		'Georgia' => '"Times New Roman", Times, serif',
-		'Helvetica Neue' => 'Arial, Helvetica, Geneva, sans-serif',
-		'Lucida Grande' => 'Lucida, Verdana, sans-serif',
-		'Tahoma' => 'Tahoma, Verdana, Segoe, sans-serif',
-		'Trebuchet MS' => 'Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif',
-		'Verdana' => 'Verdana, Geneva, sans-serif',
-	);
 
 	function __construct($defaults) {
 		$this->css = array();
 		$this->raw_css = '';
 		$this->google_fonts = array();
+		$this->web_safe = apply_filters( 'vantage_websafe_fallback', array(
+			'Arial' => 'Arial, Helvetica, sans-serif',
+			'Courier New' => 'Courier, mono',
+			'Georgia' => '"Times New Roman", Times, serif',
+			'Helvetica Neue' => 'Arial, Helvetica, Geneva, sans-serif',
+			'Lucida Grande' => 'Lucida, Verdana, sans-serif',
+			'Tahoma' => 'Tahoma, Verdana, Segoe, sans-serif',
+			'Trebuchet MS' => 'Trebuchet MS, Lucida Grande, Lucida Sans Unicode, Lucida Sans, Tahoma, sans-serif',
+			'Verdana' => 'Verdana, Geneva, sans-serif',
+		) );
 		$this->defaults = $defaults;
 	}
 
@@ -276,7 +276,7 @@ endif;
 function siteorigin_customizer_sanitize_google_font($font){
 
 	// Check the default fonts too.
-	$default_fonts = array(
+	$default_fonts = apply_filters( 'vantage_websafe', array(
 		'Arial' => 'Arial',
 		'Courier New' => 'Courier New',
 		'Georgia' => 'Georgia',
@@ -285,7 +285,7 @@ function siteorigin_customizer_sanitize_google_font($font){
 		'Tahoma' => 'Tahoma',
 		'Trebuchet MS' => 'Trebuchet MS',
 		'Verdana' => 'Verdana',
-	);
+	) );
 
 	$google_fonts = include( dirname(__FILE__).'/google-fonts.php' );
 	$font_name_parts = explode( ':', $font, 2 );


### PR DESCRIPTION
This PR will add two filters `vantage_websafe` and `vantage_websafe_fallback` that allow filtering of websafe fonts. This also indirectly allows users to add custom font - they handle the actual adding of fonts externally.

Test snippet:

```
add_filter( 'vantage_websafe', function( $websafe ) {
	$websafe['Custom Font'] = 'Custom Font';

	return $websafe;
} );

add_filter( 'vantage_websafe_fallback', function( $websafe ) {
	$websafe['Custom Font'] = 'Custom Font, sans-serif';

	return $websafe;
} );
```