### PR TITLE
Fix Vantage - Page Builder Full Width Stretched Padded Row Display

### DIFF
--- a/less/widgets.less
+++ b/less/widgets.less
@@ -758,7 +758,7 @@
 
 .layout-full .panel-row-style.panel-row-style-wide-grey,
 .layout-full .wide-grey.panel-row-style,
-.layout-full .panel-row-style.panel-row-style-full-width,
+.layout-full .panel-row-style.panel-row-style-full-width[data-stretch-type="full-stretched"],
 .layout-full.panels-style-force-full .panel-row-style{
 	margin: 0 -1000px;
 	padding: 25px 1000px 25px 1000px;

--- a/style.css
+++ b/style.css
@@ -3353,7 +3353,7 @@ html[xmlns] .slides {
 }
 .layout-full .panel-row-style.panel-row-style-wide-grey,
 .layout-full .wide-grey.panel-row-style,
-.layout-full .panel-row-style.panel-row-style-full-width,
+.layout-full .panel-row-style.panel-row-style-full-width[data-stretch-type="full-stretched"],
 .layout-full.panels-style-force-full .panel-row-style {
   margin: 0 -1000px;
   padding: 25px 1000px 25px 1000px;


### PR DESCRIPTION
@AlexGStapleton to recreate this issue:

- Activate Vantage.
- Add a Full Width Stretched Padded row with content. Note the width issue.
- Switch to this branch.

Are you happy with the solution? Let me know if you want to approach this differently, and I'll make adjustments as required.