### PR TITLE
 Google Fonts GDPR: Add Support For `siteorigin_web_font_url`

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -98,7 +98,7 @@ class SiteOrigin_Customizer_CSS_Builder {
 			}
 			$import = array_unique( $import );
 			if ( !empty( $import ) ) {
-				$return .= '@import url(//fonts.googleapis.com/css?family=' . implode( '|', $import ) . '&display=block); ';
+				$return .= '@import url(' . esc_url( apply_filters( 'siteorigin_web_font_url', 'https://fonts.googleapis.com/css' ) . '?family=' . implode( '|', $import ) . '&display=block ' ) . ');';
 			}
 		}
 


### PR DESCRIPTION
This PR will allow users to replace Google Fonts with GDPR-friendly mirrors such as [Bunny Fonts](https://fonts.bunny.net/).

Test snippet:
```
add_filter( 'siteorigin_web_font_url ', function( $url ) {
	return 'https://fonts.bunny.net/css';
} );
```

To test this snippet please add this branch into Vantage, and set the Body text to a Google Fonts hosted font.