### PR TITLE
Resolve Fonts Warning Potentially Prevented Font Import

### DIFF
--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -315,7 +315,7 @@ function siteorigin_customizer_sanitize_google_font($font){
 		'Verdana' => 'Verdana',
 	) );
 
-	$google_fonts = include( dirname(__FILE__).'/google-fonts.php' );
+	$google_fonts = include get_template_directory() . '/inc/settings/data/fonts.php';
 	$font_name_parts = explode( ':', $font, 2 );
 	$font_name = $font_name_parts[0];
 


### PR DESCRIPTION
This PR resolves a potential error that prevented front imports in the Theme Design settings.

`Warning: include(/public_html/wp-content/themes/vantage/inc/customizer/google-fonts.php): Failed to open stream: No such file or directory in /public_html/wp-content/themes/vantage/inc/customizer/customizer.php on line 318`