### PR TITLE
Always Clear `.hgroup`

### DIFF
--- a/style.css
+++ b/style.css
@@ -579,6 +579,16 @@ body {
   position: relative;
   padding-top: 45px;
   padding-bottom: 45px;
+  zoom: 1;
+}
+#masthead .hgroup:before {
+  content: '';
+  display: block;
+}
+#masthead .hgroup:after {
+  content: '';
+  display: table;
+  clear: both;
 }
 #masthead .hgroup:not(.masthead-sidebar) {
   display: flex;

--- a/style.less
+++ b/style.less
@@ -412,6 +412,7 @@ body {
 		position: relative;
 		padding-top: 45px;
 		padding-bottom: 45px;
+		.clearfix();
 		
 		&:not(.masthead-sidebar) {
 			display: flex;


### PR DESCRIPTION
This PR will clear the `.hgroup` to prevent a potential situation where the menu is stretched on tablets and covers the header. A user reported this issue and while I wasn't personally able to replicate this issue on another site.

![2023-01-05_02-39-41-1751](https://user-images.githubusercontent.com/17275120/210570363-5347881c-3cbc-472d-9b12-d6aa3c386763.jpg)
