### PR TITLE
Show Beeadcrumbs Setting If Rank Math is Detected

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -155,7 +155,7 @@ if ( ! function_exists( 'vantage_theme_settings' ) ) {
 			function_exists( 'rank_math_the_breadcrumbs' )
 		) {
 			$settings->add_field( 'navigation', 'yoast_breadcrumbs', 'checkbox', __( 'Breadcrumbs', 'vantage' ), array(
-				'description' => __( 'Display breadcrumbs if you have Yoast SEO or Breadcrumb NavXT installed.', 'vantage' ),
+				'description' => __( 'Displays breadcrumbs using your SEO or Breadcrumb plugin', 'vantage' )
 			) );
 		}
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -149,7 +149,11 @@ if ( ! function_exists( 'vantage_theme_settings' ) ) {
 			'description' => __( 'Enables Sticky Menu and Scroll To Top for mobile devices.', 'vantage' ),
 		) );
 
-		if ( function_exists( 'yoast_breadcrumb' ) || function_exists( 'bcn_display' ) ) {
+		if (
+			function_exists( 'yoast_breadcrumb' ) ||
+			function_exists( 'bcn_display' ) ||
+			function_exists( 'rank_math_the_breadcrumbs' )
+		) {
 			$settings->add_field( 'navigation', 'yoast_breadcrumbs', 'checkbox', __( 'Breadcrumbs', 'vantage' ), array(
 				'description' => __( 'Display breadcrumbs if you have Yoast SEO or Breadcrumb NavXT installed.', 'vantage' ),
 			) );


### PR DESCRIPTION
This PR allows for the Breadcrumbs setting to appear if Rank Math is installed and enabled for Breadcrumbs. Previously, it was supported but it wasn't actually possible to adjust the setting without a different supported plugin being active.