### PR TITLE
Fix Stored XSS in gallery template (CVE-2026-5070)

### DIFF
--- a/content-gallery.php
+++ b/content-gallery.php
@@ -26,7 +26,7 @@ $post_class = ( is_singular() ) ? 'post' : '';
 					<ul class="slides gallery-format-slides">
 						<?php foreach ( $gallery['src'] as $image ) { ?>
 							<li class="gallery-format-slide">
-								<img src="<?php echo $image; ?>">
+								<img src="<?php echo esc_url( $image ); ?>">
 							</li>
 						<?php } ?>
 					<ul>


### PR DESCRIPTION
## Summary
- Escapes gallery image URLs with `esc_url()` in `content-gallery.php` to fix a Stored XSS vulnerability (CVE-2026-5070, CVSS 6.4)
- A Contributor+ could craft a Gallery block with malicious text content that bypasses `wp_kses_post()` and breaks out of the `src` attribute when rendered by the theme

## Changes
`content-gallery.php:29` — `echo $image` → `echo esc_url( $image )`

## Test plan
- [x] Verify standard Gallery format posts still render images correctly
- [x] Confirm crafted payload (`src='x" onerror="alert(1)'` as block text content) is neutralized by `esc_url()`