### PR TITLE
Use overflow-x: clip for iOS scroll fix

### DIFF
--- a/style.less
+++ b/style.less
@@ -327,7 +327,7 @@ body {
 	width: 100%;
 	margin: 0;
 	padding: 0;
-	overflow: hidden;
+	overflow-x: clip;
 
 	.full-container {
 		max-width: 1080px;
@@ -797,7 +797,7 @@ body.responsive {
 	#page-wrapper {
 		max-width: 1080px;
 		width: auto;
-		overflow-x: hidden;
+		overflow-x: clip;
 	}
 
 	&.layout-full {


### PR DESCRIPTION
## Summary
- Changes `overflow: hidden` to `overflow-x: clip` on `#page-wrapper` for `.layout-full` (line 499)
- Changes `overflow-x: hidden` to `overflow-x: clip` on `#page-wrapper` for `body.responsive` (line 927)
- Fixes an issue where the footer is difficult to scroll into view on Chrome iOS when Full Width rows are used
- `overflow: hidden` creates a nested scroll context on iOS WebKit that absorbs scroll momentum; `overflow-x: clip` prevents horizontal overflow without affecting vertical scrolling

## Test plan
- [ ] Create a page with Full Width (not stretched) rows in Vantage with full layout
- [ ] Test on Chrome iOS — scroll to bottom, verify footer is easily reachable
- [ ] Verify no horizontal scrollbar appears on desktop browsers
- [ ] Test with Full Width Stretched rows
- [ ] Test with boxed layout (should be unaffected — already uses `overflow-x: visible`)
- [ ] Test without any Full Width rows to ensure no regression