### PR TITLE
Apply Buttons colours to block editor buttons

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -232,7 +232,7 @@ function vantage_customizer_init() {
 				'type' => 'color',
 				'title' => __( 'Content Link Color', 'vantage' ),
 				'default' => '#248cc8',
-				'selector' => '.entry-content a, .entry-content a:visited, article.post .author-box .box-content .author-posts a:hover, #secondary a, #secondary a:visited, #masthead .hgroup a, #masthead .hgroup a:visited, .comment-form .logged-in-as a, .comment-form .logged-in-as a:visited',
+				'selector' => '.entry-content a:not(.wp-element-button):not(.wp-block-button__link), .entry-content a:not(.wp-element-button):not(.wp-block-button__link):visited, article.post .author-box .box-content .author-posts a:not(.wp-element-button):not(.wp-block-button__link):hover, #secondary a:not(.wp-element-button):not(.wp-block-button__link), #secondary a:not(.wp-element-button):not(.wp-block-button__link):visited, #masthead .hgroup a:not(.wp-element-button):not(.wp-block-button__link), #masthead .hgroup a:not(.wp-element-button):not(.wp-block-button__link):visited, .comment-form .logged-in-as a:not(.wp-element-button):not(.wp-block-button__link), .comment-form .logged-in-as a:not(.wp-element-button):not(.wp-block-button__link):visited',
 				'property' => 'color',
 				'no_live' => true,
 			),
@@ -246,7 +246,7 @@ function vantage_customizer_init() {
 				'type' => 'color',
 				'title' => __( 'Content Link Hover Color', 'vantage' ),
 				'default' => '#f47e3c',
-				'selector' => '.entry-content a:hover, .entry-content a:focus, .entry-content a:active, #secondary a:hover, #masthead .hgroup a:hover, #masthead .hgroup a:focus, #masthead .hgroup a:active, .comment-form .logged-in-as a:hover, .comment-form .logged-in-as a:focus, .comment-form .logged-in-as a:active',
+				'selector' => '.entry-content a:not(.wp-element-button):not(.wp-block-button__link):hover, .entry-content a:not(.wp-element-button):not(.wp-block-button__link):focus, .entry-content a:not(.wp-element-button):not(.wp-block-button__link):active, #secondary a:not(.wp-element-button):not(.wp-block-button__link):hover, #masthead .hgroup a:not(.wp-element-button):not(.wp-block-button__link):hover, #masthead .hgroup a:not(.wp-element-button):not(.wp-block-button__link):focus, #masthead .hgroup a:not(.wp-element-button):not(.wp-block-button__link):active, .comment-form .logged-in-as a:not(.wp-element-button):not(.wp-block-button__link):hover, .comment-form .logged-in-as a:not(.wp-element-button):not(.wp-block-button__link):focus, .comment-form .logged-in-as a:not(.wp-element-button):not(.wp-block-button__link):active',
 				'property' => 'color',
 				'no_live' => true,
 			),
@@ -920,7 +920,7 @@ function vantage_customizer_callback_image_shadow( $builder, $val, $setting ) {
  */
 function vantage_customizer_callback_link_underline( $builder, $val, $setting ) {
 	if ( $val ) {
-		$builder->add_css( '.entry-content a, .textwidget a', 'text-decoration', 'none' );
+		$builder->add_css( '.entry-content a:not(.wp-element-button):not(.wp-block-button__link), .textwidget a:not(.wp-element-button):not(.wp-block-button__link)', 'text-decoration', 'none' );
 	}
 
 	return $builder;
@@ -935,7 +935,7 @@ function vantage_customizer_callback_link_underline( $builder, $val, $setting ) 
  */
 function vantage_customizer_callback_link_hover_underline( $builder, $val, $setting ) {
 	if ( $val ) {
-		$builder->add_css( '.entry-content a:hover, .textwidget a:hover', 'text-decoration', 'underline' );
+		$builder->add_css( '.entry-content a:not(.wp-element-button):not(.wp-block-button__link):hover, .textwidget a:not(.wp-element-button):not(.wp-block-button__link):hover', 'text-decoration', 'underline' );
 	}
 
 	return $builder;

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -752,6 +752,106 @@ function vantage_customizer_style() {
 add_action( 'wp_head', 'vantage_customizer_style', 20 );
 
 /**
+ * Normalize a hex colour for comparison against a registered default.
+ *
+ * Expands three digit shorthand so #DFD and #dfdfdf compare as equal.
+ *
+ * @param string $color
+ *
+ * @return string
+ */
+function vantage_customizer_normalize_hex( $color ) {
+	$color = strtolower( ltrim( $color, '#' ) );
+
+	if ( strlen( $color ) === 3 ) {
+		$color = $color[0] . $color[0] . $color[1] . $color[1] . $color[2] . $color[2];
+	}
+
+	return '#' . $color;
+}
+
+/**
+ * Apply the Buttons colours to blocks that use the button element.
+ *
+ * The File, Button and Search blocks are coloured by the button element in
+ * WordPress global styles, not by any theme stylesheet, so the Customizer values
+ * have to be supplied in the same layer to reach them. Doing so also covers the
+ * block editor, which never receives the CSS printed by vantage_customizer_style().
+ *
+ * Values matching their registered default are skipped, so a site that has not
+ * customized the Buttons section is left exactly as WordPress renders it.
+ *
+ * @param WP_Theme_JSON_Data $theme_json
+ *
+ * @return WP_Theme_JSON_Data
+ */
+function vantage_customizer_block_button_styles( $theme_json ) {
+	if ( ! $theme_json instanceof WP_Theme_JSON_Data ) {
+		return $theme_json;
+	}
+
+	$defaults = array(
+		'vantage_buttons_button_background' => '#dfdfdf',
+		'vantage_buttons_button_color' => '#646464',
+		'vantage_buttons_button_border' => '#c3c3c3',
+	);
+
+	$colors = array();
+
+	foreach ( $defaults as $mod => $default ) {
+		$value = get_theme_mod( $mod );
+
+		if ( ! is_string( $value ) || empty( $value ) ) {
+			continue;
+		}
+
+		$value = sanitize_hex_color( $value );
+
+		if (
+			empty( $value ) ||
+			vantage_customizer_normalize_hex( $value ) == vantage_customizer_normalize_hex( $default )
+		) {
+			continue;
+		}
+
+		$colors[ $mod ] = $value;
+	}
+
+	if ( empty( $colors ) ) {
+		return $theme_json;
+	}
+
+	$button = array();
+
+	if ( isset( $colors['vantage_buttons_button_background'] ) ) {
+		$button['color']['background'] = $colors['vantage_buttons_button_background'];
+	}
+
+	if ( isset( $colors['vantage_buttons_button_color'] ) ) {
+		$button['color']['text'] = $colors['vantage_buttons_button_color'];
+	}
+
+	if ( isset( $colors['vantage_buttons_button_border'] ) ) {
+		// WordPress sets a zero button border width, so the colour needs one to show.
+		$button['border'] = array(
+			'color' => $colors['vantage_buttons_button_border'],
+			'style' => 'solid',
+			'width' => '1px',
+		);
+	}
+
+	return $theme_json->update_with( array(
+		'version' => WP_Theme_JSON::LATEST_SCHEMA,
+		'styles' => array(
+			'elements' => array(
+				'button' => $button,
+			),
+		),
+	) );
+}
+add_filter( 'wp_theme_json_data_theme', 'vantage_customizer_block_button_styles' );
+
+/**
  * @param SiteOrigin_Customizer_CSS_Builder $builder
  * @param mixed                             $val
  * @param array                             $setting

--- a/style.css
+++ b/style.css
@@ -1759,14 +1759,14 @@ article.page.post-with-thumbnail-icon .entry-main {
   display: table;
   clear: both;
 }
-.entry-content a {
+.entry-content a:not(.wp-element-button):not(.wp-block-button__link) {
   color: #248cc8;
   -webkit-transition: all 0.2s ease;
   -moz-transition: all 0.2s ease;
   -o-transition: all 0.2s ease;
   transition: all 0.2s ease;
 }
-.entry-content a:hover {
+.entry-content a:not(.wp-element-button):not(.wp-block-button__link):hover {
   color: #f47e3c;
 }
 .entry-content p,

--- a/style.less
+++ b/style.less
@@ -1595,7 +1595,7 @@ article.page{
 	line-height: 1.6;
 	color: #666;
 
-	a{
+	a:not(.wp-element-button):not(.wp-block-button__link){
 		color: #248cc8;
 
 		.transition(0.2s);


### PR DESCRIPTION
The core File block's download button cannot be recoloured from the theme. `core/file` exposes no colour control for it — its `color.background` support paints the block wrapper — and the dark `#32373c` comes from WordPress's own `theme.json` button element, which no Vantage stylesheet touches.

Supply the Customizer Buttons colours in that same layer, via `wp_theme_json_data_theme`. This reaches the File, Button and Search blocks on the front end and in the block editor, which the CSS printed on `wp_head` never could.

**No `theme.json` file is added**, so `wp_theme_has_theme_json()` stays false and nothing gated on it changes. The filter runs regardless of whether the file exists.

Values still matching their registered default are skipped, mirroring the existing CSS builder. A site that has not customized the Buttons section emits a byte-identical global stylesheet.

A second commit stops the content link colour repainting block button labels. `.entry-content a` and friends outrank the button element rule, so block buttons were rendering with link-coloured text on a dark background. The exclusion follows WordPress's own approach for its link element and covers both classes the button element targets, so older Button block markup is caught too.

### Known limits

- Requires WordPress 7.0+, where classic themes began receiving full `theme.json` styles. Earlier versions are unaffected rather than broken.
- File blocks serialized before core added the button element class keep the core colour until the post is re-saved. The editor is unaffected.

### Verified

Against WordPress 7.1 with the theme active: byte-identical global stylesheet when uncustomized; colours applied on the front end and in the editor; a Button block with its own colour keeps it; classic buttons unchanged.