### PR TITLE
Regenerate style.css for the iOS overflow fix

### DIFF
--- a/style.css
+++ b/style.css
@@ -496,7 +496,7 @@ body {
   width: 100%;
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow-x: clip;
 }
 .layout-full #page-wrapper .full-container {
   max-width: 1080px;
@@ -924,7 +924,7 @@ body.sidebar-position-none #secondary {
 body.responsive #page-wrapper {
   max-width: 1080px;
   width: auto;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 body.responsive.layout-full #page-wrapper {
   max-width: 100%;


### PR DESCRIPTION
PR #477 changed `overflow: hidden` to `overflow-x: clip` in `style.less` but the compiled `style.css` was never regenerated, so the stylesheet WordPress actually loads still carried `overflow: hidden` and the iOS scroll fix had no effect.

Regenerated with the `less` gulp task. The diff is only the two rules from that fix; the rest of the compiled stylesheet was already in sync.