### PR TITLE
Pass the editor stylesheet version in the right argument

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -517,6 +517,7 @@ function vantage_block_editor_styles() {
 	wp_enqueue_style(
 		'vantage-block-editor-styles',
 		get_template_directory_uri() . '/style-editor.css',
+		array(),
 		SITEORIGIN_THEME_VERSION
 	);
 }


### PR DESCRIPTION
The theme version was passed as `wp_enqueue_style()`'s third argument, which is `$deps`, not `$ver`. Core casts the non-array value away, so nothing broke, but the block editor stylesheet fell back to the WordPress version and did not re-fetch on a theme update.