### PR TITLE
Size footer widgets by what is shown, and keep mobile menu images in proportion

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -379,11 +379,8 @@ if ( ! function_exists( 'vantage_print_styles' ) ) {
 		}
 
 		// Create the footer and masthead widget CSS
-		$sidebars_widgets = wp_get_sidebars_widgets();
-		$footer_count = isset( $sidebars_widgets['sidebar-footer'] ) ? count( $sidebars_widgets['sidebar-footer'] ) : 1;
-		$footer_count = max( $footer_count, 1 );
-		$masthead_count = isset( $sidebars_widgets['sidebar-masthead'] ) ? count( $sidebars_widgets['sidebar-masthead'] ) : 1;
-		$masthead_count = max( $masthead_count, 1 );
+		$footer_count = max( vantage_visible_widget_count( 'sidebar-footer' ), 1 );
+		$masthead_count = max( vantage_visible_widget_count( 'sidebar-masthead' ), 1 );
 
 		?>
 		<style type="text/css" media="screen">

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -132,18 +132,79 @@ if ( ! function_exists( 'vantage_enhanced_image_navigation' ) ) {
 }
 add_filter( 'attachment_link', 'vantage_enhanced_image_navigation', 10, 2 );
 
+if ( ! function_exists( 'vantage_visible_widget_count' ) ) {
+	/**
+	 * Count the widgets in a sidebar that will actually be displayed.
+	 *
+	 * Multilingual plugins hide widgets by returning false from
+	 * widget_display_callback, which leaves the raw sidebar count higher than the
+	 * number of widgets on the page and the columns sized too narrow. Mirror the
+	 * check WP_Widget::display_callback() makes so hidden widgets are left out.
+	 *
+	 * @param string $sidebar_id
+	 *
+	 * @return int
+	 */
+	function vantage_visible_widget_count( $sidebar_id ) {
+		global $wp_registered_widgets;
+
+		$sidebars_widgets = wp_get_sidebars_widgets();
+
+		if ( empty( $sidebars_widgets[ $sidebar_id ] ) ) {
+			return 0;
+		}
+
+		$widget_ids = (array) $sidebars_widgets[ $sidebar_id ];
+
+		if ( ! has_filter( 'widget_display_callback' ) ) {
+			return count( $widget_ids );
+		}
+
+		$count = 0;
+
+		foreach ( $widget_ids as $widget_id ) {
+			if ( empty( $wp_registered_widgets[ $widget_id ]['callback'][0] ) ) {
+				continue;
+			}
+
+			$widget = $wp_registered_widgets[ $widget_id ]['callback'][0];
+
+			if ( ! $widget instanceof WP_Widget ) {
+				// Not a WP_Widget, so there is no instance to filter.
+				$count++;
+				continue;
+			}
+
+			$number = isset( $wp_registered_widgets[ $widget_id ]['params'][0]['number'] ) ? $wp_registered_widgets[ $widget_id ]['params'][0]['number'] : -1;
+
+			// Point the widget at this instance before filtering, as WP_Widget::display_callback() does.
+			$widget->_set( $number );
+			$instances = $widget->get_settings();
+
+			if ( ! isset( $instances[ $widget->number ] ) ) {
+				continue;
+			}
+
+			if ( false !== apply_filters( 'widget_display_callback', $instances[ $widget->number ], $widget, array() ) ) {
+				$count++;
+			}
+		}
+
+		return $count;
+	}
+}
+
 if ( ! function_exists( 'vantage_footer_widget_style' ) ) {
 	/**
 	 * Add the styles to set the size of the footer widgets.
 	 */
 	function vantage_footer_widget_style() {
-		$widgets = wp_get_sidebars_widgets();
+		$count = vantage_visible_widget_count( 'sidebar-footer' );
 
-		if ( empty( $widgets['sidebar-footer'] ) ) {
+		if ( empty( $count ) ) {
 			return;
 		}
 
-		$count = count( $widgets['sidebar-footer'] );
 		?><style type="text/css" id="vantage-footer-widgets">#footer-widgets aside { width : <?php echo round( 100 / $count, 3 ); ?>%; }</style> <?php
 	}
 }

--- a/style.css
+++ b/style.css
@@ -1138,8 +1138,10 @@ body.so-vantage-mobile-device .main-navigation li:hover > ul {
   content: "\f00b";
 }
 .mobilenav-main-link img {
+  height: auto;
   max-height: 15px;
   max-width: 20px;
+  width: auto;
   margin-right: 10px;
 }
 #search-icon {

--- a/style.less
+++ b/style.less
@@ -1061,8 +1061,10 @@ body.so-vantage-mobile-device {
 
 .mobilenav-main-link {
 	img {
+		height: auto;
 		max-height: 15px;
 		max-width: 20px;
+		width: auto;
 		margin-right: 10px;
 	}
 }


### PR DESCRIPTION
Closes #335. Footer and masthead column widths were calculated from the raw sidebar widget count. Multilingual plugins hide widgets by returning false from `widget_display_callback`, so hidden widgets still consumed a column and the visible ones came out too narrow. `vantage_visible_widget_count()` now counts what will actually render, mirroring the check `WP_Widget::display_callback()` makes, including the `_set( $number )` that a plugin's filter relies on to identify the instance.

Both call sites used the raw count; both now use the helper.

Closes #360. `.mobilenav-main-link img` constrained width and height together with no `auto`, so an image carrying width and height attributes was squashed rather than scaled.

Verified locally with three footer widgets: 33.333% each normally, 50% each with one widget hidden by a `widget_display_callback` filter, and 0 for an empty or unknown sidebar.